### PR TITLE
GET params now appended to URI

### DIFF
--- a/src/ajax/core.cljs
+++ b/src/ajax/core.cljs
@@ -1,6 +1,6 @@
-(ns ajax.core  
+(ns ajax.core
   (:require [goog.net.XhrIo :as xhr]
-            [goog.Uri :as uri]            
+            [goog.Uri :as uri]
             [goog.Uri.QueryData :as query-data]
             [goog.events :as events]
             [goog.structs :as structs]
@@ -9,17 +9,17 @@
 (defn success? [status]
   (some #{status} [200 201 202 204 205 206]))
 
-(defn base-handler [& [format handler error-handler]] 
-  (fn [response]        
+(defn base-handler [& [format handler error-handler]]
+  (fn [response]
     (let [target (.-target response)
           status (.getStatus target)]
-      (if (success? status) 
+      (if (success? status)
         (if handler
           (handler (condp = (or format :edn)
                      :json (js->clj (.getResponseJson target))
                      :edn (reader/read-string (.getResponseText target))
                      (throw (js/Error. (str "unrecognized format: " format))))))
-        (if error-handler 
+        (if error-handler
           (error-handler {:status status
                           :status-text (.getStatusText target)}))))))
 
@@ -39,7 +39,7 @@
 (defn ajax-request [uri method {:keys [format handler error-handler params]}]
   (let [req              (new goog.net.XhrIo)
         response-handler (base-handler format handler error-handler)]
-    (events/listen req goog.net.EventType/COMPLETE response-handler)        
+    (events/listen req goog.net.EventType/COMPLETE response-handler)
     (.send req uri method (params-to-str params))))
 
 (defn GET
@@ -52,8 +52,8 @@
   :format - the format for the response :edn or :json defaults to :edn
   :params - a map of parameters that will be sent with the request"
   [uri & [opts]]
-  (ajax-request (uri-with-params uri (:params opts)) 
-                "GET" 
+  (ajax-request (uri-with-params uri (:params opts))
+                "GET"
                 (dissoc opts :params)))
 
 (defn POST
@@ -66,7 +66,7 @@
   :format - the format for the response :edn or :json defaults to :edn
   :params - a map of parameters that will be sent with the request"
   [uri & [opts]]
-  (ajax-request uri 
-                "POST" 
+  (ajax-request uri
+                "POST"
                 opts))
 


### PR DESCRIPTION
Previously parameters seem to have been thrown away during GET requests as they were only being passed as the POST body.

This encodes them in the URI for GET requests.
