### PR TITLE
Proposal to handle your own data formats

### DIFF
--- a/src/ajax/core.cljs
+++ b/src/ajax/core.cljs
@@ -9,21 +9,48 @@
 (defn success? [status]
   (some #{status} [200 201 202 204 205 206]))
 
-(defn parse-response [target format keywordize-keys]
-  (condp = (or format :edn)
-    :json (js->clj (.getResponseJson target) :keywordize-keys keywordize-keys)
-    :edn (reader/read-string (.getResponseText target))
-    (throw (js/Error. (str "unrecognized format: " format)))))
+(def edn-format
+  {:read (fn read-edn [target]
+           (reader/read-string (.getResponseText target)))
+   :description "EDN"})
 
-(defn exception-response [e status format is-default-format target]
+(def raw-format
+  {:read (fn read-text [target] (.getResponseText target))
+   :description "raw text"})
+
+(defn get-json-format [{:keys [prefix keywordize-keys]}]
+  {:read (fn read-json [target]
+           (let [json (if prefix
+                        (.getResponseJson target prefix)
+                        (.getResponseJson target))]
+             (js->clj json :keywordize-keys keywordize-keys)))
+   :description (str "JSON"
+                     (if prefix (str " prefix '" prefix "'"))
+                     (if keywordize-keys " keywordize"))})
+
+(defn get-default-format [target]
+  (let [ct (.getResponseHeader target "Content-Type")
+        format (if (and ct (.indexOf ct "json"))
+                (get-json-format {:keywordize-keys true})
+                :else edn-format)]
+    (update-in format [:description] #(str % " (default)"))))
+
+(defn get-format [{:keys [format] :as format-params}]
+  (cond
+   (nil? format) nil ; i.e. use get-default-format later
+   (map? format) format
+   (ifn? format) {:read format :description "custom"}
+   (= format :json) (get-json-format format-params)
+   (= format :edn) edn-format
+   (= format :raw raw-format)
+   (throw (js/Error. (str "unrecognized format: " format)))))
+
+(defn exception-response [e status format target]
   (let [response {:status status
                   :response nil}
         status-text (str (.-message e)
                          "  Format should have been "
-                         format
-                         (if is-default-format
-                           " (default)."
-                           "."))
+                         (:description format))
         parse-error (assoc response
                       :status-text status-text
                       :is-parse-error true
@@ -34,19 +61,15 @@
         :status-text (.getStatusText target)
         :parse-error parse-error))))
 
-(defn base-handler [& [format handler error-handler keywordize-keys]]
+(defn base-handler [{:keys [format handler error-handler]}]
   (fn [response]
     (try
       (let [target (.-target response)
             status (.getStatus target)
-            content-type (.getResponseHeader target "Content-Type")
-            is-default-format (nil? format)
-            format (or format
-                       (if (.indexOf content-type "json")
-                         :json
-                         :edn))]
+            format (or format (get-default-format target))
+            parse  (get format :read)]
         (try
-          (let [response (parse-response target format keywordize-keys)]
+          (let [response (parse target)]
             (if (success? status)
               (if handler
                 (handler response))
@@ -57,8 +80,7 @@
           (catch js/Object e
             (if error-handler
               (error-handler
-               (exception-response e status
-                                   format is-default-format target))))))
+               (exception-response e status format target))))))
       (catch js/Object e            ; These errors should never happen
         (if error-handler
           (error-handler {:status 0
@@ -78,13 +100,15 @@
     (str uri "?" (params-to-str params))
     uri))
 
-(defn ajax-request [uri method {:keys [format keywordize-keys handler error-handler params body headers]}]
+(defn ajax-request [uri method
+                    {:keys [params body headers] :as opts}]
   (let [req              (new goog.net.XhrIo)
-        response-handler (base-handler format handler error-handler keywordize-keys)]
+        opts             (assoc opts :format (get-format opts))
+        response-handler (base-handler opts)]
     (events/listen req goog.net.EventType/COMPLETE response-handler)
-    (if headers
-      (.send req uri method body (clj->js headers))
-      (.send req uri method (params-to-str params)))))
+    (.send req uri method
+           (or body (params-to-str params))
+           (if headers (clj->js headers)))))
 
 (defn GET
   "accepts the URI and an optional map of options, options include:


### PR DESCRIPTION
OK, this pull request does too many things

```
a) it fixes the problem that led to pull #10.
b) it adds a :raw format
c) it tidies a bit of the body/headers request
d) it gives you the ability to specify your own response format (this is how it solves a)
```

Basically, to deal with the problem is pull #10, you would need to pass in 

``` clj
(defn my-format [target] 
    (let [txt (.getResponseText target)]
        (if (seq txt)
             (js->clj (.getResponseJson target) :keywordize-keys true)
             "")))
```

and then post with `:format my-format`

So, standard JSON still behaves like standard JSON, but you can write your own special case rules for whatever is coming back from your API providers.
