### PR TITLE
Support unrolled arguments to ajax-request

### DIFF
--- a/test/test.cljs
+++ b/test/test.cljs
@@ -52,9 +52,16 @@
 (deftest correct-handler
   (let [x (FakeXhrIo. "application/edn; charset blah blah"
                       "Reply" 200)
-        r (atom nil)]
-    (ajax-request nil nil {:handler #(reset! r %)
+        r1 (atom nil)
+        r2 (atom nil)]
+    ;; Old usage of ajax-request.
+    (ajax-request nil nil {:handler #(reset! r1 %)
                            :format (raw-format)} x)
-    (is (vector? @r))
-    (is (first @r) "Request should have been successful.")
-    (is (= "Reply" (second @r)))))
+    ;; New usage with unrolled arguments.
+    (ajax-request nil nil :handler #(reset! r2 %)
+                          :format (raw-format)
+                          :manager x)
+    (doseq [r [r1 r2]]
+      (is (vector? @r))
+      (is (first @r) "Request should have been successful.")
+      (is (= "Reply" (second @r))))))


### PR DESCRIPTION
As discussed in #29.

The new usage has named arguments unrolled instead of in an explicit map, and uses `:manager` as the name of the previous unnamed, optional fourth argument. Old usage is still supported and tested.

I didn't unroll the maps passed to `GET`, `POST` and `PUT`. I can do that as a different PR, or go back and add it to this one if you would like.
