### PR TITLE
Add an example for params with an array of items

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The following settings affect the interpretation of JSON responses:  (You must s
 
 (GET "/hello" {:params {:foo "foo"}})
 
+(GET "/hello" {:params {"foo-array[]" "foo"}})
+
 (GET "/hello" {:handler handler
                :error-handler error-handler})
 


### PR DESCRIPTION
It is often the case that people need an array of items rather than a single item.
You can find a complete issue description here: https://github.com/JulianBirch/cljs-ajax/issues/40