### PR TITLE
Transit

### DIFF
--- a/src/ajax/core.cljs
+++ b/src/ajax/core.cljs
@@ -95,7 +95,7 @@
 (defn transit-response-format
   ([] (transit-response-format {}))
   ([{:keys [type reader raw] :as opts}]
-   (let [reader (or reader (t/reader (or reader :json) opts))]
+   (let [reader (or reader (t/reader (or type :json) opts))]
      {:read (transit-read reader raw)
       :description "Transit"})))
 


### PR DESCRIPTION
This removes a cljsbuild warning (possibly error) about extending a built-in Javascript type, and it fixes a small bug in the transit-response-format function so it correctly passes the type argument to the transit reader.

Thanks for the library!
