### PR TITLE
Fixes breaking of older browsers caused by extending js/FormData's type

### DIFF
--- a/src/ajax/core.cljs
+++ b/src/ajax/core.cljs
@@ -29,7 +29,8 @@
 (defprotocol DirectlySubmittable
   "A marker interface for types that can be directly sent to XhrIo")
 
-(extend-type js/FormData DirectlySubmittable)
+(when (exists? js/FormData)
+  (extend-type js/FormData DirectlySubmittable))
 
 (defn submittable? [params]
   (or (satisfies? DirectlySubmittable params)


### PR DESCRIPTION
If you're not fond of this solution I'm happy to adjust it, but having a call to extend-type on js/FormData means simply including this library breaks IE9 (and presumably any other browser that doesn't support this).
