### PR TITLE
Response types

### DIFF
--- a/browser-test/browser.cljs
+++ b/browser-test/browser.cljs
@@ -8,8 +8,9 @@
                       raw-response-format
                       transit-request-format
                       transit-response-format
-                      GET POST]])
+                      GET POST -body]])
   (:require-macros [cljs.core.async.macros :refer [go]]))
+
 
 (.log js/console "Test Results:")
 
@@ -109,3 +110,23 @@
                :response-format [:transit :edn]
                :handler handle-response
                :timeout 10000})
+
+(defn blob-response-handler
+  [[status res]]
+  (.log js/console (pr-str "status should be true:" status 
+                           "res should get a blob: " (type res) 
+                           "blob type should be application/png:" (.-type res))))
+
+(ajax-request {:uri "/ajax-form-data-png"
+               :method "POST"
+               :params (doto
+                         (js/FormData.)
+                         (.append "id" "10")
+                         (.append "timeout" "0")
+                         (.append "input" "Hello form-data POST"))
+               :api (js/XMLHttpRequest.)
+               :handler blob-response-handler
+               :response-format {:content-type "image/png"
+                                 :type :blob
+                                 :description "PNG file"
+                                 :read -body}})

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -32,6 +32,12 @@
    :headers {"Content-Type" "application/transit+json; charset=utf-8"}
    :body (write-transit response)})
 
+(defn png-response [response]
+  {:status 200
+   :headers {"Content-Type" "image/png"
+             "Content-Disposition" "inline; filename=\"foo.png\""}
+   :body "im not even a real png!"})
+
 (defn ajax-handler
   ([{{:keys [id timeout input output]} :params :as x}]
      (println x)
@@ -68,6 +74,7 @@
                                 #(assoc % :output transit-response)))
     "/ajax-url" (ajax-uri-handler request)
     "/ajax-form-data" (ajax-form-data-handler request)
+    "/ajax-form-data-png" (png-response request)
     "/favicon.ico" (rur/not-found "")))
 
 (defn sc-system [] nil)

--- a/src/ajax/core.cljs
+++ b/src/ajax/core.cljs
@@ -90,12 +90,12 @@
      {:keys [timeout with-credentials response-format]
       :or {with-credentials false
            timeout 0}}]
-    (when-let [response-type (:type response-format)]
-      (set! (.-responseType this) (name response-type)))
     (set! (.-timeout this) timeout)
     (set! (.-withCredentials this) with-credentials)
     (set! (.-onreadystatechange this) #(when (= :response-ready (ready-state %)) (handler this)))
     (.open this method uri true)
+    (when-let [response-type (:type response-format)]
+      (set! (.-responseType this) (name response-type)))
     (doseq [[k v] headers]
       (.setRequestHeader this k v))
     (.send this (or body ""))

--- a/test/test.cljs
+++ b/test/test.cljs
@@ -143,29 +143,29 @@
     (ajax-request {:handler #(reset! r1 %)
                    :format (url-request-format)
                    :response-format (raw-response-format)
-                   :manager simple-reply})
+                   :api simple-reply})
     (expect-simple-reply @r1 "{:a 1}")
     ;; Alternative usage with unrolled arguments.
     (POST nil
           :handler #(reset! r2 %)
           :format :url
           :response-format (raw-response-format)
-          :manager simple-reply)
+          :api simple-reply)
     (is (= "{:a 1}" @r2))
     ;; Test format detection runs all the way through
     (POST nil {:handler #(reset! r3 %)
                :format :url
-               :manager simple-reply})
+               :api simple-reply})
     (is (= {:a 1} @r3) "Format detection didn't work")
     (POST nil {:params (js/FormData.)
-               :manager simple-reply})
+               :api simple-reply})
     (GET "/" {:params {:a 3}
-              :manager simple-reply}
+              :api simple-reply}
     (GET "/" {:params {:a 3}
-              :manager simple-reply}
+              :api simple-reply}
          :response-format [:json :raw])
     (GET "/" {:params {:a 3}
-              :manager simple-reply}
+              :api simple-reply}
               :response-format [:json ["text/plain" :raw]]))))
 
 (deftest format-interpretation


### PR DESCRIPTION
This lets the user choose an output format for their response if they are using the XMLHttpRequest API.

Adding a type to a response format like:

```
(ajax-handler {:url "/generate.png"
               ....
               :api (js/XMLHttpRequest.)
               :response-format {:content-type "image/png" :description "PNG image" :read -body :type :buffer})
```
will return a javascript `Buffer` object.

This also fixes tests which were failing and removes some code from tests which didn't appear to be doing anything.

Unfortunately no tests were added for this feature as its a bit difficult to do without making an actual request.