### PR TITLE
Allow the basic URL to have query parameters

### DIFF
--- a/src/ajax/core.cljs
+++ b/src/ajax/core.cljs
@@ -325,8 +325,11 @@
 
 (defn uri-with-params [uri params]
   (if params
-    (str uri "?" (params-to-str params))
+    (if (re-find #"\?" uri) ;;already has some query parameters
+      (str uri "&" (params-to-str params))
+      (str uri "?" (params-to-str params)))
     uri))
+
 
 (defn get-request-format [format]
   (cond


### PR DESCRIPTION
You might have an url with some query parameters present.
If you add new parameters, they should be appended with "&" instead of "?".