### PR TITLE
Proper handling of response with 204 status code

### DIFF
--- a/src/ajax/core.cljs
+++ b/src/ajax/core.cljs
@@ -310,7 +310,7 @@
           (fail "Request aborted by client." :aborted)
           (fail "Request timed out." :timeout))
         (try
-          (let [response (read xhrio)]
+          (let [response (if (= status 204) nil (read xhrio))]
             (if (success? status)
               [true response]
               (fail (-status-text xhrio) :error :response response)))

--- a/test/test.cljs
+++ b/test/test.cljs
@@ -168,5 +168,17 @@
               :api simple-reply}
               :response-format [:json ["text/plain" :raw]]))))
 
+(deftest no-content
+  (let [r1 (atom "whatever")
+        r2 (atom "whatever")]
+    (POST "/" {:handler #(reset! r1 %)
+               :response-format (json-response-format)
+               :api (FakeXhrIo. "application/json; charset blah blah" "" 204)})
+    (is (= nil @r1))
+    (POST "/" {:handler #(reset! r2 %)
+               :response-format (json-response-format)
+               :api (FakeXhrIo. "application/json; charset blah blah" "{\"a\":\"b\"}" 200)})
+    (is (= {"a" "b"} @r2))))
+
 (deftest format-interpretation
   (is (map? (keyword-response-format {} {}))))


### PR DESCRIPTION
Hi, I'm dealing with a JSON based API, that, when deleting an entity, returns the 204 status code and empty body. It's right behaviour as it follows [RFC](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html): The 204 response MUST NOT include a message-body, and thus is always terminated by the first empty line after the header fields. The problem is how cljs-ajax handles such as responses: it calls `:error-handler` even though everything went OK.

I know the exception is thrown by `goog.json/parse` function, because empty string is invalid JSON. But I think that cljs-ajax should handle this case properly, so when 204, do not try to parse body (return `nil`).