### PR TITLE
fixes IE post issue

### DIFF
--- a/src/ajax/core.cljs
+++ b/src/ajax/core.cljs
@@ -90,10 +90,10 @@
      {:keys [timeout with-credentials response-format]
       :or {with-credentials false
            timeout 0}}]
-    (set! (.-timeout this) timeout)
     (set! (.-withCredentials this) with-credentials)
     (set! (.-onreadystatechange this) #(when (= :response-ready (ready-state %)) (handler this)))
     (.open this method uri true)
+    (set! (.-timeout this) timeout)
     (when-let [response-type (:type response-format)]
       (set! (.-responseType this) (name response-type)))
     (doseq [[k v] headers]


### PR DESCRIPTION
the timeout property must be set after open() and before send() in IE

Relevant MSDN docs:
https://msdn.microsoft.com/en-us/library/cc304105(v=vs.85).aspx

