### PR TITLE
RFC: Interceptors

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
                  [com.cemerick/clojurescript.test "0.3.3"
                   :scope "test"]
                  [org.clojure/clojurescript "0.0-3308"]
-                 [org.clojure/core.async "0.1.361.0-d8047c-alpha"]
+                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                  [com.cognitect/transit-cljs "0.8.220"]
                  [net.colourcoding/poppea "0.2.0"]]
   :plugins [[lein-cljsbuild "1.0.6"]

--- a/src/ajax/core.cljs
+++ b/src/ajax/core.cljs
@@ -347,11 +347,11 @@
     (str/upper-case (name method))
     method))
 
-(defn add-interceptor
-  "I.E. (add-interceptor {:request (fn [[uri body headers]]
-                                       (do-something-to-request uri body headers))
-                          :response (fn [resp]
-                                        (do-something-to-response resp))})"
+(defn add-default-interceptor
+  "I.E. (add-default-interceptor {:request (fn [[uri body headers]]
+                                               (do-something-to-request uri body headers))
+                                  :response (fn [resp]
+                                                (do-something-to-response resp))})"
   [interceptor]
   (swap! default-interceptors conj interceptor))
 

--- a/src/ajax/core.cljs
+++ b/src/ajax/core.cljs
@@ -355,7 +355,7 @@
 (defn apply-interceptors
   "Apply each interceptor in the `interceptors` list to the request / response."
   [stage input]
-  (loop [remaining @interceptors
+  (loop [remaining (reverse @interceptors)
          output input]
     (if (empty? remaining)
       output
@@ -373,6 +373,7 @@
                        (or headers {}))
         [uri method format params headers] (apply-interceptors :request
                                                                [uri method format params headers])]
+
     (if (= (normalize-method method) "GET")
       [(uri-with-params uri params) nil headers]
       (let [{:keys [write content-type]}
@@ -388,10 +389,8 @@
 
 (p/defn-curried js-handler [response-format handler xhrio]
   (let [response (->> xhrio
-                      (interpret-response response-format)
-                      (apply-interceptors :response))]
-    (println "@-->xhrio resp" xhrio)
-    (println "@-->handling response" response)
+                      (apply-interceptors :response)
+                      (interpret-response response-format))]
     (handler response)))
 
 (defn base-handler [response-format {:keys [handler]}]

--- a/test/test.cljs
+++ b/test/test.cljs
@@ -208,11 +208,12 @@
 
 (def response-only-interceptor
   {:response (fn [xhrio]
-               (let [resp-body (-> (.-response xhrio)
-                                   (reader/read-string)
-                                   (assoc :test-resp-interceptor true)
-                                   (str))]
-                 (set! (.-response xhrio) resp-body))
+               (if (.-response xhrio)
+                 (let [resp-body (-> (.-response xhrio)
+                                     (reader/read-string)
+                                     (assoc :test-resp-interceptor true)
+                                     (str))]
+                   (set! (.-response xhrio) resp-body)))
                xhrio)})
 
 (def request-and-response-interceptor
@@ -223,11 +224,12 @@
                (assoc params :test-req-resp-interceptor true)
                headers])
    :response (fn [xhrio]
-               (let [resp-body (-> (.-response xhrio)
-                                   (reader/read-string)
-                                   (assoc :test-req-resp-interceptor true)
-                                   (str))]
-                 (set! (.-response xhrio) resp-body))
+               (if (.-response xhrio)
+                (let [resp-body (-> (.-response xhrio)
+                                    (reader/read-string)
+                                    (assoc :test-req-resp-interceptor true)
+                                    (str))]
+                  (set! (.-response xhrio) resp-body)))
                xhrio)})
 
 (deftest test-request-interceptors
@@ -243,7 +245,7 @@
                          :method "GET"
                          :format (edn-request-format)}
                         (edn-response-format))]
-    (is (= uri "/test?a=1&test-req-interceptor=true&test-req-resp-interceptor=true")))
+    (is (= uri "/test?a=1&test-req-resp-interceptor=true&test-req-interceptor=true")))
 
   ;; test interceptor overrides
   (let [[uri payload headers]

--- a/test/test.cljs
+++ b/test/test.cljs
@@ -147,11 +147,6 @@
   (is (submittable? ""))
   (is (not (submittable? {}))))
 
-
-(GET "/" {:params {:a 3}
-          ;; ...
-          :interceptors [interceptor]})
-
 (deftest correct-handler
   (let [r1 (atom nil)
         r2 (atom nil)

--- a/test/test.cljs
+++ b/test/test.cljs
@@ -20,7 +20,7 @@
                        default-formats
                        submittable?
                        default-interceptors
-                       add-interceptor
+                       add-default-interceptor
                        POST GET]]
     [cljs.reader :as reader])
   (:require-macros [cemerick.cljs.test :refer (is deftest with-test run-tests testing)]))
@@ -147,6 +147,11 @@
   (is (submittable? ""))
   (is (not (submittable? {}))))
 
+
+(GET "/" {:params {:a 3}
+          ;; ...
+          :interceptors [interceptor]})
+
 (deftest correct-handler
   (let [r1 (atom nil)
         r2 (atom nil)
@@ -231,9 +236,9 @@
                xhrio)})
 
 (deftest test-request-interceptors
-  (add-interceptor request-only-interceptor)
-  (add-interceptor response-only-interceptor)
-  (add-interceptor request-and-response-interceptor)
+  (add-default-interceptor request-only-interceptor)
+  (add-default-interceptor response-only-interceptor)
+  (add-default-interceptor request-and-response-interceptor)
 
   ;; test global interceptors
   (let [[uri payload headers]
@@ -259,9 +264,9 @@
   (reset! default-interceptors ()))
 
 (deftest test-response-interceptors
-  (add-interceptor request-only-interceptor)
-  (add-interceptor response-only-interceptor)
-  (add-interceptor request-and-response-interceptor)
+  (add-default-interceptor request-only-interceptor)
+  (add-default-interceptor response-only-interceptor)
+  (add-default-interceptor request-and-response-interceptor)
 
   (let [r1 (atom nil)
         r2 (atom nil)]


### PR DESCRIPTION
This is still incomplete. But before I get too far, I just wanted some feedback.

### Proposed usage

Here is my proposed usage of this feature:

~~~clojure
;; define an interceptor. the :request and :response are both optional
(def interceptor
  {:request (fn [[uri method format params headers]]
              ;; do something to the above arguments, then return the new values
              [uri method format params headers])

   :response (fn [xhrio]
               ;; do something to the xhrio object, then return the new value
               xhrio)})

;; add the interceptor to the list
(ajax.core/add-default-interceptor interceptor)

;; or you can just edit the atom directly. this will be useful if the interceptors need
;; to be run in a certain order, and one needs to be spliced into the list or something
(swap! ajax.core/default-interceptors conj interceptor)

;; OR interceptors can be passed to the `ajax-request` method for explicit overrides.
;; the following block will replace the default interceptor list for this request only
(GET "/" {:params {:a 3}
          ;; ...
          :interceptors [interceptor-override]})
~~~

### Issues

The biggest issue that I've run into is with the current ajax response format. The interceptor implementation in this PR passes the entire `xhrio` object as the argument for each response interceptor:

~~~clojure
;; this example adds {:test-resp-interceptor true} to the response body
(def response-interceptor
  {:response (fn [xhrio]
               (let [resp-body (-> (.-response xhrio)
                                   (reader/read-string)
                                   (assoc :test-resp-interceptor true)
                                   (str))]
                 (set! (.-response xhrio) resp-body))
               xhrio)})
~~~

This is necessary because the `xhrio` object contains information that may be needed by the interceptor, such as the status and headers of the response.

But this is annoying because we have to deal with a mutable JS object, and it seems like we need to parse / unparse the response body at each step in the sequence.

It would be nice if we could do something like this instead:

~~~clojure
(def response-interceptor
  {:response (fn [[input-body status headers request-config]]
               (let [output-body (assoc input-body :test-resp-interceptor true)]
                 [output-body status headers request-config]))})
~~~

Where the `body`, `headers`, and `request-config` are clojure maps instead of strings that we need to parse. And we could infer the success based on the status code instead of having it be a boolean as it is now. (Because sometimes it's necessary to treat a `404` differently than a `401` or a `500` error for example.)

But this would require a breaking change to the current implementation, and this is probably better suited for another PR.

Anyway let me know if I'm on the right path, and let me know if you have any issues with my coding style or naming conventions. I'm not sensitive about this stuff at all :smiley:

**Note**: I wasn't able to run the test suite without updating to the latest version of `core.async`, so that change is included in this PR. Let me know if this is a problem and I can break that change out into a separate PR.