### PR TITLE
Transit-CLJ

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,10 @@ addons:
   firefox: "24.0"
 before_script:
   - "sh -e /etc/init.d/xvfb start"
-  - "echo 'Installing Slimer'"
   - "curl https://slimerjs.org/slimerjs-pubkey.gpg | gpg --import"
   - "wget http://download.slimerjs.org/releases/0.9.6/slimerjs-0.9.6-linux-x86_64.tar.bz2"
   - "wget http://download.slimerjs.org/releases/0.9.6/slimerjs-0.9.6-linux-x86_64.tar.bz2.asc"
   - "gpg --verify-files *.asc"
   - "tar jxfv slimerjs-0.9.6-linux-x86_64.tar.bz2"
-  - "mv slimerjs-0.9.6-linux-x86_64 ./slimerjs"
+  - "mv slimerjs-0.9.6 ./slimerjs"
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,10 @@ addons:
 before_script:
   - "sh -e /etc/init.d/xvfb start"
   - "echo 'Installing Slimer'"
-  - "wget http://download.slimerjs.org/v0.9.6/slimerjs-0.9.6.zip"
-  - "unzip slimerjs-0.9.6.zip"
-  - "mv slimerjs-0.9.6 ./slimerjs"
+  - "curl https://slimerjs.org/slimerjs-pubkey.gpg | gpg --import"
+  - "wget http://download.slimerjs.org/releases/0.9.6/slimerjs-0.9.6-linux-x86_64.tar.bz2"
+  - "wget http://download.slimerjs.org/releases/0.9.6/slimerjs-0.9.6-linux-x86_64.tar.bz2.asc"
+  - "gpg --verify-files *.asc"
+  - "tar jxfv slimerjs-0.9.6-linux-x86_64.tar.bz2"
+  - "mv slimerjs-0.9.6-linux-x86_64 ./slimerjs"
 sudo: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #cljs-ajax
 
-simple Ajax client for ClojureScript and Clojure
+Simple Ajax client for Clojure(Script)
 
 `cljs-ajax` exposes the same interface (where useful) in both Clojure and ClojureScript. On ClojureScript it operates as a wrapper around [`goog.net.XhrIo`](https://developers.google.com/closure/library/docs/xhrio?hl=en) or [`js\XmlHttpRequest`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest), while on the JVM it's a wrapper around the [Apache HttpAsyncClient](https://hc.apache.org/httpcomponents-asyncclient-dev/) library.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Simple Ajax client for Clojure(Script)
 
+[![Build Status](https://travis-ci.org/JulianBirch/cljs-ajax.svg?branch=master)](https://travis-ci.org/JulianBirch/cljs-ajax)
+
 `cljs-ajax` exposes the same interface (where useful) in both Clojure and ClojureScript. On ClojureScript it operates as a wrapper around [`goog.net.XhrIo`](https://developers.google.com/closure/library/docs/xhrio?hl=en) or [`js\XmlHttpRequest`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest), while on the JVM it's a wrapper around the [Apache HttpAsyncClient](https://hc.apache.org/httpcomponents-asyncclient-dev/) library.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Simple Ajax client for Clojure(Script)
 
 [![Build Status](https://travis-ci.org/JulianBirch/cljs-ajax.svg?branch=master)](https://travis-ci.org/JulianBirch/cljs-ajax)
 
-`cljs-ajax` exposes the same interface (where useful) in both Clojure and ClojureScript. On ClojureScript it operates as a wrapper around [`goog.net.XhrIo`](https://developers.google.com/closure/library/docs/xhrio?hl=en) or [`js\XmlHttpRequest`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest), while on the JVM it's a wrapper around the [Apache HttpAsyncClient](https://hc.apache.org/httpcomponents-asyncclient-dev/) library.
+`cljs-ajax` exposes the same interface (where useful) in both Clojure and ClojureScript. On ClojureScript it operates as a wrapper around [`goog.net.XhrIo`](https://developers.google.com/closure/library/docs/xhrio?hl=en) or [`js/XmlHttpRequest`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest), while on the JVM it's a wrapper around the [Apache HttpAsyncClient](https://hc.apache.org/httpcomponents-asyncclient-dev/) library.
 
 ## Usage
 

--- a/project.clj
+++ b/project.clj
@@ -47,6 +47,7 @@
           :compiler {:output-to "target-int/integration.js"
                      :output-dir "target-int"
                                         ; :source-map "target-int/integration.js.map"
+                     :warnings {:single-segment-namespace false}
                      :optimizations :whitespace
                      :pretty-print true}}}
    :test-commands {"unit-tests"

--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,7 @@
                  [org.clojure/clojurescript "1.7.107"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                  [com.cognitect/transit-cljs "0.8.220"]
+                 [com.cognitect/transit-clj "0.8.281"]
                  [net.colourcoding/poppea "0.2.0"]
                  [org.apache.httpcomponents/httpcore "4.4.1"]
                  [org.apache.httpcomponents/httpclient "4.5"]
@@ -31,21 +32,21 @@
    {:dev  {:source-paths ["src"]
            :compiler {:output-to "target/main.js"
                       :output-dir "target"
-                      ; :source-map "target/main.js.map"
+                                        ; :source-map "target/main.js.map"
                       :optimizations :whitespace
                       :pretty-print true}}
     :test {:source-paths ["src" "test"]
            :incremental? true
            :compiler {:output-to "target-test/unit-test.js"
                       :output-dir "target-test"
-                      ; :source-map "target-test/unit-test.js.map"
+                                        ; :source-map "target-test/unit-test.js.map"
                       :optimizations :whitespace
                       :pretty-print true}}
     :int {:source-paths ["src" "browser-test"]
           :incremental? true
           :compiler {:output-to "target-int/integration.js"
                      :output-dir "target-int"
-                     ; :source-map "target-int/integration.js.map"
+                                        ; :source-map "target-int/integration.js.map"
                      :optimizations :whitespace
                      :pretty-print true}}}
    :test-commands {"unit-tests"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cljs-ajax "0.5.0-SNAPSHOT"
+(defproject cljs-ajax "0.5.1-SNAPSHOT"
   :description "A simple Ajax library for ClojureScript"
   :url "https://github.com/JulianBirch/cljs-ajax"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -20,6 +20,7 @@
             [com.cemerick/clojurescript.test "0.3.3"]]
   :hooks [leiningen.cljsbuild]
   :global-vars { *warn-on-reflection* true }
+  :clean-targets ^{:protect false} ["target" "target-int" "target-test"]
   :profiles
   {:dev {:source-paths ["dev", "browser-test"]
          :dependencies [[ring-server "0.4.0"]


### PR DESCRIPTION
I was trying to add an interceptor for cljs-ajax to my bitauth project and I discovered that you need this dependency apparently.

Also, I added clean targets so `lein clean` works properly now and silenced some complaints cljsbuild was emiting for one of your compile targets.