### PR TITLE
Bump transit-cljs dependency to fix UUID hashing issues

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,8 +6,8 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[cheshire "5.5.0"]
                  [com.cemerick/clojurescript.test "0.3.3" :scope "test"]
-                 [com.cognitect/transit-clj "0.8.281"]
-                 [com.cognitect/transit-cljs "0.8.225"]
+                 [com.cognitect/transit-clj "0.8.285"]
+                 [com.cognitect/transit-cljs "0.8.232"]
                  [net.colourcoding/poppea "0.2.1"]
                  [org.apache.httpcomponents/httpasyncclient "4.1"]
                  [org.apache.httpcomponents/httpcore "4.4.3"]


### PR DESCRIPTION
See the upstream commit below for the fix. Without this, UUIDs
deserialized from cljs-ajax responses will not hash correctly,
breaking key lookups in maps etc.

https://github.com/cognitect/transit-cljs/commit/bc36a898cd1195979c26e5927f31ca0069e49fd3

Note: Updating `transit-clj` is not necessary for this but I guess it doesn't
hurt bumping that as well.