### PR TITLE
Set the response type if it's specified in the response format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,8 @@ The following settings affect the interpretation of JSON responses:  (You must s
 (PUT "/add-item"
      {:params {:id 1 :name "mystery item"}})
      
-(ajax-handler {:url "/generate.png" ; Request a PNG and get it back as a js/ArrayBuffer
-               :api (js/XMLHttpRequest.)
-               :response-format {:content-type "image/png" :description "PNG image" :read -body :type :arraybuffer})
+(GET {:url "/generate.png" ; Request a PNG and get it back as a js/ArrayBuffer
+      :response-format {:content-type "image/png" :description "PNG image" :read -body :type :arraybuffer})
 ```
 
 ### FormData support

--- a/src/ajax/xhrio.cljs
+++ b/src/ajax/xhrio.cljs
@@ -13,10 +13,13 @@
   AjaxImpl
   (-js-ajax-request
     [this
-     {:keys [uri method body headers timeout with-credentials]
+     {:keys [uri method body headers timeout with-credentials
+             response-format]
       :or {with-credentials false
            timeout 0}}
      handler]
+    (when-let [response-type (:type response-format)]
+      (.setResponseType this (name response-type)))
     (doto this
       (events/listen goog.net.EventType/COMPLETE
                      #(handler (.-target %)))
@@ -26,7 +29,7 @@
   AjaxRequest
   (-abort [this] (.abort this goog.net.ErrorCode/ABORT))
   AjaxResponse
-  (-body [this] (.getResponseText this))
+  (-body [this] (.getResponse this))
   (-status [this] (.getStatus this))
   (-status-text [this] (.getStatusText this))
   (-get-response-header [this header]


### PR DESCRIPTION
This PR ports across the `:type` response format parameter from the XMLHttpRequest API, fixing #143.

I tested it by requesting an mp3 into an arraybuffer and playing it in Chrome.

I'm not deeply familiar with browser quirks, so please sanity check this before merging. :-)