### PR TITLE
Updated to README and interceptors documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The following parameters are the same as in the `GET`/`POST` easy api:
 * `:timeout` - the ajax call's timeout.  30 seconds if left blank
 * `:headers` - a map of the HTTP headers to set with the request
 * `:with-credentials` - a boolean, whether to set the `withCredentials` flag on the XHR object.
-* `:interceptors` - the [interceptors](docs/Interceptors.md) to run for this request. If not set, runs contents of the `default-interceptors` global atom. This is an empty vector by default. For more information, visit the [interceptors page](docs/Interceptors.md).
+* `:interceptors` - the [interceptors](docs/interceptors.md) to run for this request. If not set, runs contents of the `default-interceptors` global atom. This is an empty vector by default. For more information, visit the [interceptors page](docs/interceptors.md).
 
 ### `ajax-request` examples
 

--- a/docs/interceptors.md
+++ b/docs/interceptors.md
@@ -69,10 +69,10 @@ We may wish to see a rule *appended*, however. The Google App Engine doesn't per
 Finally, many systems return an empty JSON response when returning `nil`. Strictly speaking, they should return `"null"`.
 
 ```clj
-(def empty-means-nil [response]
-     (if (-response-text response)
-         response
-         (reduced [(-> response -status success?) nil])))
+(defn empty-means-nil [response]
+      (if (ajax.protocols/-body response)
+          response
+          (reduced [(-> response ajax.protocols/-status ajax.core/success?) nil])))
 
 (def treat-nil-as-empty
      (to-interceptor {:name "JSON special case nil"


### PR DESCRIPTION
Hi Julian,
Would you consider merging this PR?
I noticed a couple of broken links in your README and some broken documentation about interceptors. I've also tried to make it clear that the way to use the response in a response interceptor is via the functions in the AjaxResponse protocol, as it wasn't too obvious to me originally.
Thanks,
Dean.