### PR TITLE
Don't automatically add charset to Accept headers

### DIFF
--- a/src/ajax/core.cljc
+++ b/src/ajax/core.cljc
@@ -94,7 +94,6 @@
   (->> (if (string? content-type)
          [content-type]
          content-type)
-       (map #(str % "; charset=utf-8"))
        (str/join ", ")))
 
 (defrecord ResponseFormat [read description content-type]
@@ -289,7 +288,7 @@
 
 (defn url-request-format []
   {:write (to-utf8-writer params-to-str)
-   :content-type "application/x-www-form-urlencoded"})
+   :content-type "application/x-www-form-urlencoded; charset=utf-8"})
 
 (defn raw-response-format
   ([] (map->ResponseFormat {:read -body
@@ -300,7 +299,7 @@
 
 (defn text-request-format []
   {:write (to-utf8-writer identity)
-   :content-type "text/plain"})
+   :content-type "text/plain; charset=utf-8"})
 
 #? (:clj
     ;;; http://stackoverflow.com/questions/309424/read-convert-an-inputstream-to-a-string

--- a/test/ajax/test/core.cljc
+++ b/test/ajax/test/core.cljc
@@ -37,9 +37,9 @@
 
 (deftest complex-params-to-str
   (is (= "a=0" (params-to-str {:a 0})))
-  (is (= "b[0]=1&b[0]=2" (params-to-str {:b [1 2]})))
+  (is (= "b[0]=1&b[1]=2" (params-to-str {:b [1 2]})))
   (is (= "c[d]=3&c[e]=4" (params-to-str {:c {:d 3 :e 4}})))
-  (is (= "f=5" (params-to-str {"d" 5})))
+  (is (= "d=5" (params-to-str {"d" 5})))
   (is (= "a=0&b[0]=1&b[1]=2&c[d]=3&c[e]=4&f=5"
          (params-to-str {:a 0
                          :b [1 2]

--- a/test/ajax/test/core.cljc
+++ b/test/ajax/test/core.cljc
@@ -1,7 +1,7 @@
 (ns ajax.test.core
   (:require
    #? (:cljs [cljs.test]
-             :clj [clojure.test :refer :all])
+       :clj [clojure.test :refer :all])
    [ajax.protocols :refer [-body]]
    [ajax.core :refer [get-default-format
                       normalize-method
@@ -88,11 +88,11 @@
   (is (vector? (keyword-response-format [:json :transit] {})))
   (is (map? (first (keyword-response-format [:json :transit] {}))))
   (is (= ["application/json"] (accept-header {:response-format [(json-response-format {})]})))
-  (is (= (multi-content-type [:json :transit])
-         #? (:clj ["application/json" "application/transit+msgpack" "application/transit+json"]
-             :cljs ["application/json" "application/transit+json"])))
-  (is (= (multi-content-type [:json ["text/plain" :raw]])
-         ["application/json" "text/plain"])))
+  (is (= #? (:clj ["application/json" "application/transit+msgpack" "application/transit+json"]
+             :cljs ["application/json" "application/transit+json"])
+         (multi-content-type [:json :transit])))
+  (is (= ["application/json" "text/plain"]
+         (multi-content-type [:json ["text/plain" :raw]]))))
 
 ;;; Somewhat ugly that this isn't exactly the same code as runs
 ;;; in ajax-request
@@ -113,10 +113,11 @@
                          :method "POST"
                          :format (edn-request-format)
                          :response-format (edn-response-format)})]
-    (is (= uri "/test"))
-    (is (= (as-string body) "{:a 3, :b \"hello\"}"))
-    (is (= headers {"Content-Type" "application/edn; charset=utf-8"
-                    "Accept" "application/edn; charset=utf-8"}))))
+    (is (= "/test" uri))
+    (is (= "{:a 3, :b \"hello\"}" (as-string body)))
+    (is (= {"Content-Type" "application/edn; charset=utf-8"
+            "Accept" "application/edn; charset=utf-8"}
+           headers))))
 
 (deftest regression-no-formats
   (let [{:keys [headers]}
@@ -127,7 +128,7 @@
                          :format (keyword-request-format nil {})
                          :response-format (keyword-response-format nil
   {})})]
-    (is (= (get headers "Accept") "application/json; charset=utf-8, application/transit+json; charset=utf-8, application/transit+transit; charset=utf-8, text/plain; charset=utf-8, text/html; charset=utf-8, */*; charset=utf-8"))))
+    (is (= "application/json; charset=utf-8, application/transit+json; charset=utf-8, application/transit+transit; charset=utf-8, text/plain; charset=utf-8, text/html; charset=utf-8, */*; charset=utf-8" (get headers "Accept")))))
 
 (deftest can-add-to-query-string
   (let [{:keys [uri]}
@@ -136,7 +137,7 @@
                          :uri "/test?extra=true"
                          :method "GET"
                          :response-format (edn-response-format)})]
-    (is (= uri "/test?extra=true&a=3&b=hello"))))
+    (is (= "/test?extra=true&a=3&b=hello" uri))))
 
 (deftest use-interceptor
   (let [interceptor (to-interceptor
@@ -148,7 +149,7 @@
                          :method "GET"
                          :response-format (edn-response-format)
                          :interceptors [interceptor]})]
-    (is (= uri "/test?extra=true&a=3&b=hello&c=world"))))
+    (is (= "/test?extra=true&a=3&b=hello&c=world" uri))))
 
 (deftest process-inputs-as-edn
   (let [{:keys [uri body headers]}
@@ -158,7 +159,7 @@
                          :method "GET"
                          :format (edn-request-format)
                          :response-format (edn-response-format)})]
-    (is (= uri "/test?a=3&b=hello"))
+    (is (= "/test?a=3&b=hello" uri))
     (is (nil? body))
     (is (= {"Accept" "application/edn; charset=utf-8"} headers))))
 
@@ -170,11 +171,12 @@
                          :method "POST"
                          :format (url-request-format)
                          :response-format (json-response-format)})]
-    (is (= uri "/test"))
-    (is (= (as-string body) "a=3&b=hello"))
-    (is (= headers {"Content-Type"
-                    "application/x-www-form-urlencoded; charset=utf-8"
-                    "Accept" "application/json; charset=utf-8"}))))
+    (is (= "/test" uri))
+    (is (= "a=3&b=hello" (as-string body)))
+    (is (= {"Content-Type"
+            "application/x-www-form-urlencoded; charset=utf-8"
+            "Accept" "application/json; charset=utf-8"}
+           headers))))
 
 #? (:cljs (deftest body-is-passed-through
             (let [result (process-inputs {:body (js/FormData.)

--- a/test/ajax/test/core.cljc
+++ b/test/ajax/test/core.cljc
@@ -115,8 +115,8 @@
                          :response-format (edn-response-format)})]
     (is (= "/test" uri))
     (is (= "{:a 3, :b \"hello\"}" (as-string body)))
-    (is (= {"Content-Type" "application/edn; charset=utf-8"
-            "Accept" "application/edn; charset=utf-8"}
+    (is (= {"Content-Type" "application/edn"
+            "Accept" "application/edn"}
            headers))))
 
 (deftest regression-no-formats
@@ -126,9 +126,8 @@
                          :uri "/test"
                          :method "POST"
                          :format (keyword-request-format nil {})
-                         :response-format (keyword-response-format nil
-  {})})]
-    (is (= "application/json; charset=utf-8, application/transit+json; charset=utf-8, application/transit+transit; charset=utf-8, text/plain; charset=utf-8, text/html; charset=utf-8, */*; charset=utf-8" (get headers "Accept")))))
+                         :response-format (keyword-response-format nil {})})]
+    (is (= "application/json, application/transit+json, application/transit+transit, text/plain, text/html, */*" (get headers "Accept")))))
 
 (deftest can-add-to-query-string
   (let [{:keys [uri]}
@@ -161,7 +160,7 @@
                          :response-format (edn-response-format)})]
     (is (= "/test?a=3&b=hello" uri))
     (is (nil? body))
-    (is (= {"Accept" "application/edn; charset=utf-8"} headers))))
+    (is (= {"Accept" "application/edn"} headers))))
 
 (deftest process-inputs-as-raw
   (let [{:keys [uri body headers]}
@@ -175,7 +174,7 @@
     (is (= "a=3&b=hello" (as-string body)))
     (is (= {"Content-Type"
             "application/x-www-form-urlencoded; charset=utf-8"
-            "Accept" "application/json; charset=utf-8"}
+            "Accept" "application/json"}
            headers))))
 
 #? (:cljs (deftest body-is-passed-through

--- a/test/ajax/test/core.cljc
+++ b/test/ajax/test/core.cljc
@@ -36,10 +36,10 @@
                      [java.io ByteArrayInputStream])))
 
 (deftest complex-params-to-str
-  (is (= "a=0") (params-to-str {:a 0}))
-  (is (= "b[0]=1&b[0]=2") (params-to-str {:b [1 2]}))
-  (is (= "c[d]=3&c[e]=4") (params-to-str {:c {:d 3 :e 4}}))
-  (is (= "f=5") (params-to-str {"d" 5}))
+  (is (= "a=0" (params-to-str {:a 0})))
+  (is (= "b[0]=1&b[0]=2" (params-to-str {:b [1 2]})))
+  (is (= "c[d]=3&c[e]=4" (params-to-str {:c {:d 3 :e 4}})))
+  (is (= "f=5" (params-to-str {"d" 5})))
   (is (= "a=0&b[0]=1&b[1]=2&c[d]=3&c[e]=4&f=5"
          (params-to-str {:a 0
                          :b [1 2]


### PR DESCRIPTION
1. This builds atop the small test fixes I submitted in #146. Recommend merging that first.
2. This is one approach to fixing #138. There are a few different ways that could be done, but this seems like the best to me. There are a number of subtle implications, which I've tried to lay out below.
3. The approach here is to remove the universal behavior of adding `charset=utf-8` everywhere, and instead to add it back in to the particular formats where it makes sense. This also allows the user to override the built-in behavior any time they desire to do so.

---

The charset parameter which was automatically added is invalid for some content types whose specification demands a particular charset (e.g. JSON, EDN), and thus this behavior renders cljs-ajax broken when talking to some standards-compliant web servers (e.g. Yada).

**NOTE: The behavior introduced in this commit is not backwards compatible.**  Of the four core formats, `:transit`, `:json`, `:text` and `:raw`...

1. `:transit` and `:json` will now do the right thing and not send invalid charsets.
2. `:text` and `:raw` will continue to send `charset=utf-8`, as before.
3. If a `:content-type` is explicitly specified, it will be respected (unlike before, when it would have been changed and there was no way to prevent this).

Finally, the `Accept` headers sent will no longer include charsets.  Not only does the validity of such parameters [seem to be in question][1], but even the seemingly-more-legitimate `Accept-Charset` [seems to be falling out of favor][2].

[1]: http://stackoverflow.com/a/7310784
[2]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation#The_Accept-Charset_header