### PR TITLE
Clean up `print-response`, `print-error-response`

### DIFF
--- a/src/ajax/core.cljc
+++ b/src/ajax/core.cljc
@@ -541,17 +541,15 @@
     (keyword-response-format-element format format-params)))
 
 (defn print-response [response]
-  (println "CLJS-AJAX response:  " response))
+  (println "CLJS-AJAX response:" response))
 
 (def default-handler (atom print-response))
 
 (defn print-error-response [response]
-  #? (:clj (println "CLJS-AJAX ERROR: " response)
-      :cljs (if-let [c js/window.console]
-          (.error c response)
-          (if-let [w js/Window]
-            (.alert w (str response))
-            (println "CLJS-AJAX ERROR: " response)))))
+  #? (:clj  (println "CLJS-AJAX ERROR:" response)
+      :cljs (cond (exists? js/console) (.error js/console response)
+                  (exists? js/window)  (.alert js/window (str response))
+                  :else                (println "CLJS-AJAX ERROR:" response))))
 
 (def default-error-handler
   (atom print-error-response))


### PR DESCRIPTION
Follow up to 18b9c3b3ae3cde970467da35c94a51a158d504c2.

- Logically invalid to check for a window inside of a check for `window.console`.
- `Window.alert` is invalid (`Window` is the class, not the instance, which has the method we want to use)
- `console.log` is more widely available than `window.console.log` (headless environments, etc.)
- `println` already adds spaces between its arguments.
- Stylistically speaking, there's really no reason to be binding the various bits of JS to other names—they already have names we can use directly and efficiently.

/cc @msprunck (let me know if you disagree with anything here—happy to discuss)