### PR TITLE
Give better error messages in ajax-call with keywords as formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,10 @@ The `error-handler` for `GET`, `POST`, and `PUT` is passed one parameter which i
 ## ajax-request
 
 The `ajax-request` is the simple interface.  It differs from the GET and POST API as follows:
+
+* **You can't use keywords to specify formats. You must provide a complete format in your request (see the [formats documentation](docs/formats.md) for more details)**
+* The API is harder to use.
 * You can use your own formats.
-* You can't use keywords to specify formats.  The API is harder to use.
 * It compiles to smaller code when advanced optimizations are switched on.
 * It doesn't do Content-Type discovery.
 * There's only one handler, so you have to handle errors.

--- a/test/ajax/test/core.cljc
+++ b/test/ajax/test/core.cljc
@@ -23,6 +23,7 @@
                       process-request
                       process-response
                       transform-opts
+                      get-request-format
                       get-response-format
                       params-to-str
                       apply-request-format
@@ -286,6 +287,12 @@
     (is (instance? ResponseFormat (get-response-format request)))
     (let [format (get-default-format simple-reply request)]
       (is format))))
+
+(deftest response-format-kw
+  (is (thrown-with-msg? #?(:clj Exception :cljs js/Error) #"keywords are not allowed as response formats in ajax calls:" (get-response-format {:response-format :json}))))
+
+(deftest request-format-kw
+  (is (thrown-with-msg? #?(:clj Exception :cljs js/Error) #"keywords are not allowed as request formats in ajax calls:" (get-request-format :json))))
 
 (deftest json-parsing
   (let [response (FakeXhrIo. "application/json; charset blah blah" "while(1);{\"a\":\"b\"}" 200)]


### PR DESCRIPTION
`ajax-call` requires users to specify full request and response formats, not just keywords. Because keywords are IFn's they fall into the `ifn?`  branch of the cond. This means that errors propagate further downstream and are more confusing when they finally break.

This patch adds an assertion that keywords aren't passed as formats, and throws a more informative error message if they are.

There are also some tweaks to the README to make the need to provide full formats more clear.
