### PR TITLE
support url encoding (plus sign in particular)

### DIFF
--- a/src/ajax/core.cljc
+++ b/src/ajax/core.cljc
@@ -171,10 +171,12 @@
                (.flush)))))
 
 (defn params-to-str [params]
-  (->> (seq params)
-       (mapcat (param-to-str nil))
-       (map (fn [[k v]] (str k "=" v)))
-       (str/join "&")))
+  (let [url-encode-fn #? (:clj (fn [u] (java.net.URLEncoder/encode (str u) "UTF-8"))
+                          :cljs js/encodeURIComponent)]
+    (->> (seq params)
+         (mapcat (param-to-str nil))
+         (map (fn [[k v]] (str k "=" (url-encode-fn v))))
+         (str/join "&"))))
 
 (p/defn-curried uri-with-params [params params-to-str uri]
   (if params

--- a/test/ajax/test/core.cljc
+++ b/test/ajax/test/core.cljc
@@ -44,7 +44,8 @@
          (params-to-str {:a 0
                          :b [1 2]
                          :c {:d 3 :e 4}
-                         "f" 5}))))
+                         "f" 5})))
+  (is (= "a=b%2Bc" (params-to-str {:a "b+c"}))))
 
 (deftest normalize
   (is (= "GET" (normalize-method :get)))


### PR DESCRIPTION
Parameter value can contain special characters that must be encoded properly (for example plus sign, it must be encoded and interpreted as is, not as space).
