### PR TITLE
Add PURGE method - implemented by caching services such as varnish

### DIFF
--- a/src/ajax/core.cljc
+++ b/src/ajax/core.cljc
@@ -590,3 +590,4 @@
 (m/easy-api OPTIONS)
 (m/easy-api TRACE)
 (m/easy-api PATCH)
+(m/easy-api PURGE)


### PR DESCRIPTION
Request to add support for the PURGE HTTP method.  It's not part of the formal HTTP spec, but is implemented by popular caching libraries/services such as Varnish.