### PR TITLE
[apache] Need to close the closeable client.

### DIFF
--- a/src/ajax/apache.clj
+++ b/src/ajax/apache.clj
@@ -92,29 +92,45 @@
       (.setSocketTimeout builder st))
     (.build builder)))
 
-(defn- to-clojure-future [^Future future]
+(defn- to-clojure-future [^Future future ^java.io.Closeable client]
   "Converts a normal Java future to one similar to the one generated
    by `clojure.core/future`"
   (reify
     clojure.lang.IDeref
-    (deref [_] (.get future))
+    (deref [_]
+      (try
+        (.get future)
+        (finally (.close client))))
     clojure.lang.IBlockingDeref
     (deref [_ timeout-ms timeout-val]
       (try
         (.get future timeout-ms
               java.util.concurrent.TimeUnit/MILLISECONDS)
         (catch java.util.concurrent.TimeoutException e
-          timeout-val)))
+          timeout-val)
+        (finally (.close client))))
     clojure.lang.IPending
     (isRealized [_] (.isDone future))
     java.util.concurrent.Future
-    (get [_] (.get future))
-    (get [_ timeout unit] (.get future timeout unit))
+    (get [_]
+      (try
+        (.get future)
+        (finally (.close client))))
+    (get [_ timeout unit]
+      (try
+        (.get future timeout unit)
+        (finally (.close client))))
     (isCancelled [_] (.isCancelled future))
     (isDone [_] (.isDone future))
-    (cancel [_ interrupt?] (.cancel future interrupt?))
+    (cancel [_ interrupt?]
+      (try
+        (.cancel future interrupt?)
+        (finally (.close client))))
     ajax.protocols.AjaxRequest
-    (-abort [_] (.cancel future true))))
+    (-abort [_]
+      (try
+        (.cancel future true)
+        (finally (.close client))))))
 
 (defrecord Connection []
   AjaxImpl
@@ -133,5 +149,5 @@
         (doseq [x headers]
           (let [[h v] x]
             (.addHeader request h v)))
-        (to-clojure-future (.execute client request h)))
+        (to-clojure-future (.execute client request h) client))
       (catch Exception ex (fail handler ex)))))


### PR DESCRIPTION
From Clojure (not cljs): Without closing this client, we can run out of handles and then all subsequent requests fail.

With these deps:
```
[cljs-ajax "0.5.9"]
[http-kit "2.2.0"]
```

And this program:
```
(ns cljs-ajax-post-fail.core
  (:require [clojure.pprint]
            [org.httpkit.server :as server]
            [ajax.core :refer [POST]])
  (:gen-class))

(defn -main
  [& args]
  (let [port 8080]
    (server/run-server (fn [req]
                         {:status 200
                          :headers {"Content-Type" "text/plain"}
                          :body "Hi!"}) {:port port})
    (println "Trying a thousand posts...")
    (dotimes [_ 1000]
      @(POST (str "http://localhost:" port)
             {:handler (fn [resp] (print "."))}))
    (println "\nDone!")
    (flush)
    (System/exit 0)))
```

On the master branch of cljs-ajax we are seeing errors like these:
```
May 08, 2017 10:50:28 AM org.apache.http.impl.nio.client.InternalHttpAsyncClient run
SEVERE: I/O reactor terminated abnormally
org.apache.http.nio.reactor.IOReactorException: Failure opening selector
	at org.apache.http.impl.nio.reactor.AbstractIOReactor.<init>(AbstractIOReactor.java:105)
	at org.apache.http.impl.nio.reactor.BaseIOReactor.<init>(BaseIOReactor.java:87)
	at org.apache.http.impl.nio.reactor.AbstractMultiworkerIOReactor.execute(AbstractMultiworkerIOReactor.java:320)
	at org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager.execute(PoolingNHttpClientConnectionManager.java:191)
	at org.apache.http.impl.nio.client.CloseableHttpAsyncClientBase$1.run(CloseableHttpAsyncClientBase.java:64)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.IOException: Too many open files
	at sun.nio.ch.EPollArrayWrapper.epollCreate(Native Method)
	at sun.nio.ch.EPollArrayWrapper.<init>(EPollArrayWrapper.java:130)
	at sun.nio.ch.EPollSelectorImpl.<init>(EPollSelectorImpl.java:69)
	at sun.nio.ch.EPollSelectorProvider.openSelector(EPollSelectorProvider.java:36)
	at java.nio.channels.Selector.open(Selector.java:227)
	at org.apache.http.impl.nio.reactor.AbstractIOReactor.<init>(AbstractIOReactor.java:103)
	... 5 more
```

In long-running Clojure (not cljs) processes that make lots of requests.

With the code in this PR that program succeeds. I don't actually know much about the apache http internals, but this client does implement `java.io.Closable`, so presumably we should be closing it.

Hope that helps! Thanks for this lib, if it didn't exist, then we'd be spending time making something resembling it.