### PR TITLE
Issue 181: Force close client even when not dereferenced

### DIFF
--- a/src/ajax/apache.clj
+++ b/src/ajax/apache.clj
@@ -92,45 +92,14 @@
       (.setSocketTimeout builder st))
     (.build builder)))
 
-(defn- to-clojure-future [^Future future ^java.io.Closeable client]
+(defn- to-clojure-future
   "Converts a normal Java future to one similar to the one generated
    by `clojure.core/future`"
-  (reify
-    clojure.lang.IDeref
-    (deref [_]
-      (try
-        (.get future)
-        (finally (.close client))))
-    clojure.lang.IBlockingDeref
-    (deref [_ timeout-ms timeout-val]
-      (try
-        (.get future timeout-ms
-              java.util.concurrent.TimeUnit/MILLISECONDS)
-        (catch java.util.concurrent.TimeoutException e
-          timeout-val)
-        (finally (.close client))))
-    clojure.lang.IPending
-    (isRealized [_] (.isDone future))
-    java.util.concurrent.Future
-    (get [_]
-      (try
-        (.get future)
-        (finally (.close client))))
-    (get [_ timeout unit]
-      (try
-        (.get future timeout unit)
-        (finally (.close client))))
-    (isCancelled [_] (.isCancelled future))
-    (isDone [_] (.isDone future))
-    (cancel [_ interrupt?]
-      (try
-        (.cancel future interrupt?)
-        (finally (.close client))))
-    ajax.protocols.AjaxRequest
-    (-abort [_]
-      (try
-        (.cancel future true)
-        (finally (.close client))))))
+  [^Future fut ^java.io.Closeable client]
+  (future
+    (try
+      (.get fut)
+      (finally (.close client)))))
 
 (defrecord Connection []
   AjaxImpl

--- a/src/ajax/apache.clj
+++ b/src/ajax/apache.clj
@@ -24,7 +24,7 @@
 (defn- to-entity [b]
   (condp instance? b
     array-of-bytes-type (ByteArrayEntity. b)
-    String (StringEntity. b "UTF-8")
+    String (StringEntity. ^String b "UTF-8")
     File (FileEntity. b)
     InputStream (InputStreamEntity. b)
     b))


### PR DESCRIPTION
This solves #181, but creates overhead of an extra `future`.