### PR TITLE
Added support for progress-handler for XhrIo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ pom.xml.asc
 .lein-repl-history
 .nrepl-port
 *~
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ For advice on how to set up the server side in Clojure to work with cljs-ajax, p
 The `GET`, `POST`, and `PUT` helpers accept a URI followed by a map of options:
 
 * `:handler` - the handler function for successful operation should accept a single parameter which is the deserialized response. If you do not provide a handler, the contents of the `default-handler` atom will be called instead. By default this is `println`.
+* `:progress-handler` - the handler function for progress events. **This handler is only available when using the `goog.net.XhrIo` API**
 * `:error-handler` - the handler function for errors, should accept an error response (detailed below). If you do not provide an error-handler, the contents of the `default-error-handler` atom will be called instead. By default this is `println` for Clojure and writes an error to the console for ClojureScript.
 * `:finally` - a function that takes no parameters and will be triggered during the callback in addition to any other handlers
 * `:format` - specifies the format for the body of the request (Transit, JSON, etc.). Also sets the appropriate `Content-Type` header.  Defaults to `:transit` if not provided.

--- a/browser-test/browser.cljc
+++ b/browser-test/browser.cljc
@@ -23,6 +23,9 @@
 (defn handle-error [error]
   (println "Error" error))
 
+(defn handle-progress [e]
+  (println (str "Progress (" (.-loaded e) "/" (.-total e) ")")))
+
 (defn blob-response-handler
   [[status res]]
   (println (pr-str "status should be true:" status
@@ -176,6 +179,7 @@
                            :api (js/XMLHttpRequest.)
                            :handler blob-response-handler
                            :error-handler handle-error
+                           :progress-handler handle-progress
                            :response-format {:content-type "image/png"
                                              :type :blob
                                              :description "PNG file"

--- a/browser-test/browser.cljc
+++ b/browser-test/browser.cljc
@@ -179,6 +179,20 @@
                            :api (js/XMLHttpRequest.)
                            :handler blob-response-handler
                            :error-handler handle-error
+                           :response-format {:content-type "image/png"
+                                             :type :blob
+                                             :description "PNG file"
+                                             :read -body}}))
+
+  #? (:cljs (ajax-request {:uri "/ajax-form-data-png"
+                           :method "POST"
+                           :body (doto
+                                   (js/FormData.)
+                                   (.append "id" "19")
+                                   (.append "timeout" "0")
+                                   (.append "input" "Hello form-data POST"))
+                           :handler blob-response-handler
+                           :error-handler handle-error
                            :progress-handler handle-progress
                            :response-format {:content-type "image/png"
                                              :type :blob

--- a/src/ajax/macros.clj
+++ b/src/ajax/macros.clj
@@ -9,6 +9,8 @@
         :handler - the handler function for successful operation
                    should accept a single parameter which is the
                    deserialized response
+        :progress-handler - the handler function for progress events.
+                            this handler is only available when using the goog.net.XhrIo API
         :error-handler - the handler function for errors, should accept a
                          map with keys :status and :status-text
         :format - the format for the request

--- a/src/ajax/xhrio.cljs
+++ b/src/ajax/xhrio.cljs
@@ -20,7 +20,7 @@
      handler]
     (when-let [response-type (:type response-format)]
       (.setResponseType this (name response-type)))
-    (when progress-handler
+    (when (fn? progress-handler)
       (doto this
         (.setProgressEventsEnabled true)
         (events/listen goog.net.EventType.UPLOAD_PROGRESS progress-handler)))

--- a/src/ajax/xhrio.cljs
+++ b/src/ajax/xhrio.cljs
@@ -14,12 +14,16 @@
   (-js-ajax-request
     [this
      {:keys [uri method body headers timeout with-credentials
-             response-format]
+             response-format progress-handler]
       :or {with-credentials false
            timeout 0}}
      handler]
     (when-let [response-type (:type response-format)]
       (.setResponseType this (name response-type)))
+    (when progress-handler
+      (doto this
+        (.setProgressEventsEnabled true)
+        (events/listen goog.net.EventType.UPLOAD_PROGRESS progress-handler)))
     (doto this
       (events/listen goog.net.EventType/COMPLETE
                      #(handler (.-target %)))


### PR DESCRIPTION

**Doc**
 `:progress-handler` - the handler function for progress events. **This handler is only available when using the `goog.net.XhrIo` API**

**Example**
```
(ajax/PUT url
          {:handler          (fn [data]
                               (println "Success"))
           :progress-handler (fn [e]
                               (println (str "Progress (" (.-loaded e) "/" (.-total e) ")  [" (* 100 (/ (.-loaded e) (.-total e))) "]%")))
           :format           :raw
           :body             js-file})
```

Excited to get this in!  👍 
 
Thanks,
R