### PR TITLE
Close client even if future not dereferenced, allow abort

### DIFF
--- a/src/ajax/apache.clj
+++ b/src/ajax/apache.clj
@@ -1,7 +1,8 @@
 (ns ajax.apache
   (:require [ajax.protocols :refer [map->Response]]
             [clojure.string :as s])
-  (:import [org.apache.http HttpResponse]
+  (:import [clojure.lang IDeref IBlockingDeref IPending]
+           [org.apache.http HttpResponse]
            [org.apache.http.entity ByteArrayEntity StringEntity
             FileEntity InputStreamEntity]
            [org.apache.http.client.methods HttpRequestBase
@@ -14,7 +15,7 @@
            [java.lang Exception]
            [java.util.concurrent Future]
            [java.net URI SocketTimeoutException]
-           [java.io File InputStream]))
+           [java.io File InputStream Closeable]))
 
 ;;; Chunks of this code liberally ripped off dakrone/clj-http
 ;;; Although that uses the synchronous API
@@ -92,45 +93,38 @@
       (.setSocketTimeout builder st))
     (.build builder)))
 
-(defn- to-clojure-future [^Future future ^java.io.Closeable client]
+(defn- to-clojure-future
   "Converts a normal Java future to one similar to the one generated
    by `clojure.core/future`"
-  (reify
-    clojure.lang.IDeref
-    (deref [_]
-      (try
-        (.get future)
-        (finally (.close client))))
-    clojure.lang.IBlockingDeref
-    (deref [_ timeout-ms timeout-val]
-      (try
-        (.get future timeout-ms
-              java.util.concurrent.TimeUnit/MILLISECONDS)
-        (catch java.util.concurrent.TimeoutException e
-          timeout-val)
-        (finally (.close client))))
-    clojure.lang.IPending
-    (isRealized [_] (.isDone future))
-    java.util.concurrent.Future
-    (get [_]
-      (try
-        (.get future)
-        (finally (.close client))))
-    (get [_ timeout unit]
-      (try
-        (.get future timeout unit)
-        (finally (.close client))))
-    (isCancelled [_] (.isCancelled future))
-    (isDone [_] (.isDone future))
-    (cancel [_ interrupt?]
-      (try
-        (.cancel future interrupt?)
-        (finally (.close client))))
-    ajax.protocols.AjaxRequest
-    (-abort [_]
-      (try
-        (.cancel future true)
-        (finally (.close client))))))
+  [^Future f ^Closeable client]
+  (let [^Future f* (future
+                     (try
+                       (.get f)
+                       (finally (.close client))))
+        cancel* (fn [interrupt?]
+                  (try
+                    (.cancel f interrupt?)
+                    (.cancel f* interrupt?)
+                    (finally (.close client))))]
+    (reify
+      IDeref
+      (deref [_] (deref f*))
+      IBlockingDeref
+      (deref [_ timeout-ms timeout-val]
+        (deref f* timeout-ms timeout-val))
+      IPending
+      (isRealized [_] (.isDone f*))
+      Future
+      (get [_] (.get f*))
+      (get [_ timeout unit]
+        (.get f* timeout unit))
+      (isCancelled [_] (.isCancelled f*))
+      (isDone [_] (.isDone f*))
+      (cancel [_ interrupt?]
+        (cancel* interrupt?))
+      AjaxRequest
+      (-abort [_]
+        (cancel* true)))))
 
 (defrecord Connection []
   AjaxImpl


### PR DESCRIPTION
**Fixes: #181**
Closes the client even if the future is not dereferenced, allows aborting the request.