### PR TITLE
Add a ring-response-format

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -21,6 +21,7 @@ There are functions that return request and response formats.  Most of these fun
 | `:transit`  | `transit-request-format` | `transit-response-format` |
 | `:json` | `json-request-format` | `json-response-format` |
 | `:url`  | `url-request-format` | |
+| `:ring` | | `ring-response-format` |
 | `:raw`  | | `raw-response-format` |
 | `:text`  | `text-request-format` | `text-response-format` |
 | `:detect` | | `detect-response-format` |
@@ -46,6 +47,13 @@ There are functions that return request and response formats.  Most of these fun
 * `:java` will render `{:a [1 2]}` as `a=1&a=2`. This works with yada, ASP and Jetty (ring). It also matches the behaviour of superagent.
 * `:rails` will render `{:a [1 2]}` as `a[]=1&a[]=2`. This is also the correct setting for working with PHP and matches the behaviour of jQuery.
 * `:indexed` will render `{:a [1 2]}` as `a[0]=1&a[1]=2`. This is mostly kept for backwards compatibility and shouldn't be used in new code.
+
+### Ring parameters
+
+`ring-response-format` takes one parameter: `format`. This can be any
+valid request format map as described above. The `:read` function will
+be used to populate the `:body` key of the response and the
+`:content-type` key will be used instead of the default `*/*`.
 
 ### Detect parameters
 
@@ -73,6 +81,3 @@ To get the raw XhrIo object back:
 ```clj
 {:read identity :description "raw"}
 ```
-
-Incidentally, if anyone wants to implement a response format that returns the response in a ring-style format, I accept pull requests.
-

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -10,7 +10,7 @@ A response format (given by `:response-format`) is a bit more complex:
 * `:description` A description of the format, for use in error messages.
 * `:read` A function that takes the underlying `goog.net.XhrIo` and converts it to a response.  Exceptions thrown by this will be caught.
 * `:content-type` The content type to put in the `Accept` header.
-* `:type` Optional.  One of `:blob`, `:document`, `:json` (which uses the browser's JSON decoding to a JS object), `:text` (same as blank), `:arraybuffer`. Set `:read` to `-body` if you want to use this. 
+* `:type` Optional.  One of `:blob`, `:document`, `:json` (which uses the browser's JSON decoding to a JS object), `:text` (same as blank), `:arraybuffer`. Set `:read` to `-body` if you want to use this.
 
 ## Standard Formats
 
@@ -31,10 +31,10 @@ There are functions that return request and response formats.  Most of these fun
 
 `transit-request-format` takes one parameter: `writer`, which is the transit writer.  If you don't supply one, it'll create a default one.
 
-`transit-response-format` has two parameters: `reader` which is the transit reader and `:raw` which, if true, causes a JS object to be returned rather than a CLJS object. 
+`transit-response-format` has two parameters: `reader` which is the transit reader and `:raw` which, if true, causes a JS object to be returned rather than a CLJS object.
 
 ### JSON parameters
- 
+
 `json-response-format` takes two parameters
 * `:prefix` is a string that needs to be stripped off the front of the response before parsing it as JSON, which is useful for dealing with external APIs that put things like `while(1);` in front.  (And if you're using cljs-ajax with `GET`, learn about cross-site scripting and then employ this feature in your own code.)  Defaults to `nil`.
 * `:keywords?`, which if true returns the keys as keywords and if false or unprovided returns them as strings.
@@ -57,12 +57,12 @@ EDN is deprecated, but the functions `edn-request-format` and `edn-response-form
 
 ### Google Closure JSON
 
-Earlier versions used Google Closure's implementation of JSON. This was the 
-correct choice at the time since native implementations were pretty 
-inconsistent. These days, it's more likely that you'll want to be using the 
-browser native JSON implementation which is vastly faster and handles dates 
+Earlier versions used Google Closure's implementation of JSON. This was the
+correct choice at the time since native implementations were pretty
+inconsistent. These days, it's more likely that you'll want to be using the
+browser native JSON implementation which is vastly faster and handles dates
 better, but if you still need the old behaviour you can get it by using
-`goog-json-request-format` and `goog-json-response-format` in the 
+`goog-json-request-format` and `goog-json-response-format` in the
 `ajax.goog-json` namespace. They support the same options as the standard JSON
 implementation and share most of the internal code.
 

--- a/src/ajax/apache.clj
+++ b/src/ajax/apache.clj
@@ -3,7 +3,7 @@
               AjaxImpl AjaxRequest AjaxResponse]]
             [clojure.string :as s])
   (:import [clojure.lang IDeref IBlockingDeref IPending]
-           [org.apache.http HttpResponse]
+           [org.apache.http HttpResponse Header]
            [org.apache.http.entity ByteArrayEntity StringEntity
             FileEntity InputStreamEntity]
            [org.apache.http.client.methods HttpRequestBase
@@ -62,6 +62,12 @@
   (-status-text [this]
     (let [^HttpResponse response (:response this)]
       (-> response .getStatusLine .getReasonPhrase)))
+  (-get-all-headers [this]
+    (let [^HttpResponse response (:response this)]
+      (reduce (fn [headers ^Header header]
+                (assoc headers (.getName header) (.getValue header)))
+              {}
+              (.getAllHeaders response))))
   (-get-response-header [this header]
     (let [^HttpResponse response (:response this)]
       (.getValue (.getFirstHeader response header))))

--- a/src/ajax/apache.clj
+++ b/src/ajax/apache.clj
@@ -120,9 +120,9 @@
 (defn- to-clojure-future
   "Converts a normal Java future to one similar to the one generated
    by `clojure.core/future`. Operationally, this is used to wrap the
-   result of the Apache API into something that can be returned by 
-   `ajax-request`. Note that there's no guarantee anyone will ever dereference 
-   it (but they might). Also, since it's returned by `ajax-request`, 
+   result of the Apache API into something that can be returned by
+   `ajax-request`. Note that there's no guarantee anyone will ever dereference
+   it (but they might). Also, since it's returned by `ajax-request`,
    it needs to support `abort`."
   [^Future f ^Closeable client]
   ;;; We wrap the original future and closeable in a second layer
@@ -179,8 +179,8 @@
 
 (defn new-api []
   "This is the only thing exposed by the apache.clj file:
-   a factory function that returns a class that wraps the 
-   Apache async API to the cljs-ajax API. 
+   a factory function that returns a class that wraps the
+   Apache async API to the cljs-ajax API.
    Note that it's completely stateless: all of the relevant
    implementation objects are created each time."
 

--- a/src/ajax/core.cljc
+++ b/src/ajax/core.cljc
@@ -5,6 +5,7 @@
             [ajax.url :as url]
             [ajax.json :as json]
             [ajax.transit :as transit]
+            [ajax.ring :as ring]
             [ajax.formats :as f]
             [ajax.util :as u]
             [ajax.interceptors :as i]
@@ -21,7 +22,7 @@
 
 ;;; NB As a matter of policy, this file shouldn't reference any
 ;;; google closure files. That functionality should be off in
-;;; specific namespaces and exposed here in a platform indepdent 
+;;; specific namespaces and exposed here in a platform indepdent
 ;;; way
 
 ;;; Ideally this would be true of all functionality, but it's
@@ -30,7 +31,7 @@
 (def to-interceptor i/to-interceptor)
 
 (defn abort [this]
-  "Call this on the result of `ajax-request` to cancel the request." 
+  "Call this on the result of `ajax-request` to cancel the request."
   (pr/-abort this))
 
 ;;; Standard Formats
@@ -40,6 +41,8 @@
 
 (def transit-request-format transit/transit-request-format)
 (def transit-response-format transit/transit-response-format)
+
+(def ring-response-format ring/ring-response-format)
 
 (def url-request-format url/url-request-format)
 

--- a/src/ajax/easy.cljc
+++ b/src/ajax/easy.cljc
@@ -64,8 +64,8 @@
   (println "CLJS-AJAX response:" response))
 
 (def default-handler
-  "This gets called if you forget to attach a handler to an easy 
-  API function." 
+  "This gets called if you forget to attach a handler to an easy
+  API function."
   (atom print-response))
 
 (defn print-error-response [response]

--- a/src/ajax/easy.cljc
+++ b/src/ajax/easy.cljc
@@ -2,6 +2,7 @@
     (:require [ajax.simple :as simple]
               [ajax.transit :as t]
               [ajax.json :as json]
+              [ajax.ring :as ring]
               [ajax.url :as url]
               [ajax.formats :as f]))
 
@@ -45,6 +46,7 @@
            :transit (t/transit-response-format format-params)
            :json (json/json-response-format format-params)
            :text (f/text-response-format)
+           :ring (ring/ring-response-format)
            :raw (f/raw-response-format)
            :detect (detect-response-format)
            nil)))

--- a/src/ajax/protocols.cljc
+++ b/src/ajax/protocols.cljc
@@ -18,6 +18,8 @@
     "Returns the HTTP Status of the response as an integer.")
   (-status-text [this]
     "Returns the HTTP Status Text of the response as a string.")
+  (-get-all-headers [this]
+    "Returns all headers as a map.")
   (-body [this]
     "Returns the response body as a string or as type specified in response-format such as a blob or arraybuffer.")
   (-get-response-header [this header]
@@ -37,5 +39,6 @@
   (-body [this] (:body this))
   (-status [this] (:status this))
   (-status-text [this] (:status-text this))
+  (-get-all-headers [this] (:headers this))
   (-get-response-header [this header] (get (:headers this) header))
   (-was-aborted [this] (:was-aborted this)))

--- a/src/ajax/ring.cljc
+++ b/src/ajax/ring.cljc
@@ -1,0 +1,24 @@
+(ns ajax.ring
+  (:require [ajax.interceptors :refer [map->ResponseFormat]]
+            [ajax.protocols :refer [-status -get-all-headers -body]]))
+
+(defn make-ring-read [body-read]
+  (fn ring-read [response]
+    {:status (-status response)
+     :headers (-get-all-headers response)
+     :body (body-read response)}))
+
+(defn ring-response-format
+  "Returns a Ring-compatible response map.
+
+   Optionally can be passed a :format option. This should be another
+  response-format map. If format is provided it will be used to
+  specify the content-type, and the read method will be used to
+  populate the :body key in the response map."
+  ([] (ring-response-format {:format {:read -body
+                                      :description "raw body"
+                                      :content-type ["*/*"]}}))
+  ([{:keys [format]}]
+   (map->ResponseFormat {:read (make-ring-read (:read format))
+                         :description (str "ring/" (:description format))
+                         :content-type (:content-type format)})))

--- a/src/ajax/xhrio.cljs
+++ b/src/ajax/xhrio.cljs
@@ -36,6 +36,8 @@
   (-body [this] (.getResponse this))
   (-status [this] (.getStatus this))
   (-status-text [this] (.getStatusText this))
+  (-get-all-headers [this]
+    (js->clj (.getResponseHeaders this)))
   (-get-response-header [this header]
     (.getResponseHeader this header))
   (-was-aborted [this]

--- a/test/ajax/test/core.cljc
+++ b/test/ajax/test/core.cljc
@@ -115,7 +115,7 @@
 ; NB This also tests that the vec-strategy has reverted to :java
 (deftest can-add-to-query-string
   (let [{:keys [uri]}
-        (process-inputs {:params {:a [3 4] :b "hello"} 
+        (process-inputs {:params {:a [3 4] :b "hello"}
                          :headers nil
                          :uri "/test?extra=true"
                          :method "GET"
@@ -272,9 +272,9 @@
       (is format))))
 
 (deftest response-format-kw
-  (is (thrown-with-msg? 
-      #?(:clj Exception :cljs js/Error) 
-      #"keywords are not allowed as response formats in ajax calls:" 
+  (is (thrown-with-msg?
+      #?(:clj Exception :cljs js/Error)
+      #"keywords are not allowed as response formats in ajax calls:"
       (get-response-format detect-response-format {:response-format :json}))))
 
 (deftest request-format-kw

--- a/test/ajax/test/core.cljc
+++ b/test/ajax/test/core.cljc
@@ -38,6 +38,7 @@
   (-js-ajax-request [this _ h]
     (h this))
   ajax.protocols/AjaxResponse
+  (-get-all-headers [this])
   (-get-response-header [this header] content-type)
   (-status [_] status)
   (-body [_] #? (:cljs response


### PR DESCRIPTION
Also integrate it into the easy keyword-based API.

This is a first pass, based on the discussion in #180.  I'm not sure if it makes sense to specify a `ring-request-format` as well.  Feedback much appreciated.