### PR TITLE
Fix for nodejs/npm-deps support

### DIFF
--- a/src/ajax/xml_http_request.cljs
+++ b/src/ajax/xml_http_request.cljs
@@ -28,7 +28,7 @@
 
 (def xmlhttprequest
   (if (= cljs.core/*target* "nodejs")
-    (let [xmlhttprequest (.-XMLHttpRequest (js/require "@pupeno/xmlhttprequest"))]
+    (let [xmlhttprequest (.-XMLHttpRequest (js/require "xmlhttprequest"))]
       (goog.object/set js/global "XMLHttpRequest" xmlhttprequest)
       xmlhttprequest)
     (.-XMLHttpRequest js/window)))


### PR DESCRIPTION
The "@pupeno" portion of the string causes issues when trying to use npm-deps, as it needs to be a keyword. Removing it fixes this issue.