### PR TITLE
Fix documentation of detect-response-format

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -57,7 +57,7 @@ the `:ring` keyword.)
 
 ### Detect parameters
 
-`detect-response-format` has one parameter: `:defaults`, which is a list of pairs.  The first item in the pair is a substring that starts the content type.  The second item is the response format function to call.  It will be passed the options in.  So, you can, for instance, have `:raw` set to `true` and content detection available at the same time.  If you use the zero-arity version, `:defaults` is set to `default-formats`.
+`detect-response-format` has one parameter: `:response-format`, which is a list of pairs.  The first item in the pair is a substring that starts the content type.  The second item is the response format function to call.  It will be passed the options in.  So, you can, for instance, have `:raw` set to `true` and content detection available at the same time.  If you use the zero-arity version, `:response-format` is set to `default-formats`.
 
 ### EDN
 


### PR DESCRIPTION
It seems that `:defaults` was renamed to `:response-format` in commit b48c327dd80de66a2463622dbac9422f98b9e99f but that the documentation wasn’t changed accordingly.