### PR TITLE
Update transit-cljs dependency to latest (0.8.243) version.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[cheshire "5.7.1"]
                  [com.cognitect/transit-clj "0.8.300"]
-                 [com.cognitect/transit-cljs "0.8.239"]
+                 [com.cognitect/transit-cljs "0.8.243"]
                  [net.colourcoding/poppea "0.2.1"]
                  [org.apache.httpcomponents/httpasyncclient "4.1.3"]
                  [org.apache.httpcomponents/httpcore "4.4.6"]


### PR DESCRIPTION
This should fix the ```uri? already refers to: cljs.core/uri? being replaced by: cognitect.transit/uri?``` compilation warning. Also, ```lein run-tests``` was successful. Output follows:
```
Retrieving com/cognitect/transit-cljs/0.8.243/transit-cljs-0.8.243.pom from central
Retrieving com/cognitect/transit-cljs/0.8.243/transit-cljs-0.8.243.jar from central
Compiling ClojureScript...
Compiling "target/main.js" from ["src"]...
Successfully compiled "target/main.js" in 9.561 seconds.
Compiling "target-test/unit-test.js" from ["src" "test"]...
Successfully compiled "target-test/unit-test.js" in 10.814 seconds.
Test Results:
Compiling "target-int/integration.js" from ["src" "browser-test"]...
Successfully compiled "target-int/integration.js" in 8.449 seconds.
Compiling ClojureScript...

lein test ajax.test.core
CLJS-AJAX response: {:a 1}
CLJS-AJAX response: {:a 1}
CLJS-AJAX response: {:a 1}

lein test ajax.test.server-interaction

lein test ajax.test.url

Ran 28 tests containing 75 assertions.
0 failures, 0 errors.

;; ======================================================================
;; Testing with Phantom:


Testing ajax.test.core
CLJS-AJAX response: {:a 1}
CLJS-AJAX response: {:a 1}
CLJS-AJAX response: {:a 1}
CLJS-AJAX response: {:a 1}

Ran 24 tests containing 48 assertions.
0 failures, 0 errors.
```