### PR TITLE
Documentation fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ New releases tend to get announced on Twitter with credit to contributors.
 If you want an @mention, make sure to tell us your handle.
 Equally, if you don't want to be mentioned, make sure to tell us that.
 
-If you're looking for something to do some open source work, take a look at the issue tracker. `cljs-ajax` always has a lot of issues marked welcome". Drop a li"PR ne if you're interested in working on anything.
+If you're looking for something to do some open source work, take a look at the issue tracker. `cljs-ajax` always has a lot of [issues marked "PR welcome"](https://github.com/JulianBirch/cljs-ajax/issues?q=is%3Aissue+is%3Aopen+label%3A%22PR+welcome%22). Drop a line if you're interested in working on anything.
 
 After that `lein run-tests` should run the tests.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The client provides an easy way to send Ajax requests to the server using `GET`,
 There are four formats currently supported for communicating with the server:  `:transit`, `:json`, `:text` and `:raw`.
 (`:text` will send parameters up using normal form submission and return the raw text. `:raw` does the same, but on the JVM it returns the body's `java.io.InputStream` and *doesn't close it*.)
 
-For advice on how to set up the server side in Clojure to work with cljs-ajax, please see the page on [handling responses on the server](docs/server.md).
+For advice on how to set up the server side in Clojure to work with `cljs-ajax`, please see the page on [handling responses on the server](docs/server.md).
 
 ## GET/POST/PUT
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In addition to this document, there's an [FAQ](docs/faq.md), a [change log](CHAN
 
 ## Usage
 
-Leiningen
+Leiningen: `[cljs-ajax "0.7.3"]`
 
 [![Leiningen version](http://clojars.org/cljs-ajax/latest-version.svg)](http://clojars.org/cljs-ajax)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#cljs-ajax
+# cljs-ajax
 
 simple Ajax client for ClojureScript and Clojure
 


### PR DESCRIPTION
This PR fixes two typos, makes two tiny changes to documentation, and adds a copy/paste-able Leiningen dependency string to the README. That last item will require future maintenance as versions change, but I and others find it useful.