### PR TITLE
Added :url-params field

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The `GET`, `POST`, and `PUT` helpers accept a URI followed by a map of options:
 * `:format` - specifies the format for the body of the request (Transit, JSON, etc.). Also sets the appropriate `Content-Type` header.  Defaults to `:transit` if not provided.
 * `:response-format` - specifies that you'd like to receive a certain format of data from the server (by setting the `Accept` header and forcing the response to be parsed as the desired format).  If not provided, a permissive `Accept` header will be sent, and the response body will be interpreted according to the response's `Content-Type` header.
 * `:params` - the parameters that will be sent with the request,  format dependent: `:transit` and `:edn` can send anything, `:json`, `:text` and `:raw` need to be given a map.  `GET` will add params onto the query string, `POST` will put the params in the body
+* `:url-params` - parameters that will be added to the url. These parameters will always be added to the url unless it's a GET request. GET requests always put parameters from :params in the url.
 * `:timeout` - the ajax call's timeout in milliseconds.  30 seconds if left blank
 * `:headers` - a map of the HTTP headers to set with the request
 * `:with-credentials` - a boolean, whether to set the `withCredentials` flag on the XHR object.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The `GET`, `POST`, and `PUT` helpers accept a URI followed by a map of options:
 * `:format` - specifies the format for the body of the request (Transit, JSON, etc.). Also sets the appropriate `Content-Type` header.  Defaults to `:transit` if not provided.
 * `:response-format` - specifies that you'd like to receive a certain format of data from the server (by setting the `Accept` header and forcing the response to be parsed as the desired format).  If not provided, a permissive `Accept` header will be sent, and the response body will be interpreted according to the response's `Content-Type` header.
 * `:params` - the parameters that will be sent with the request,  format dependent: `:transit` and `:edn` can send anything, `:json`, `:text` and `:raw` need to be given a map.  `GET` will add params onto the query string, `POST` will put the params in the body
-* `:url-params` - parameters that will be added to the url. These parameters will always be added to the url unless it's a GET request. GET requests always put parameters from :params in the url.
+* `:url-params` - parameters that will be added onto query string. In the case of a GET request, parameters defined here will replace parameters defined in `:params`.
 * `:timeout` - the ajax call's timeout in milliseconds.  30 seconds if left blank
 * `:headers` - a map of the HTTP headers to set with the request
 * `:with-credentials` - a boolean, whether to set the `withCredentials` flag on the XHR object.

--- a/src/ajax/interceptors.cljc
+++ b/src/ajax/interceptors.cljc
@@ -173,9 +173,9 @@
 (m/defn-curried ^:internal uri-with-params [{:keys [vec-strategy params method url-params]} uri]
   "Internal function. Takes a uri and appends the interpretation of the query string to it
    matching the behaviour of `url-request-format`."
-  (if-let [final-url-params (if (= method "GET")
-                        params
-                        url-params)]
+  (if-let [final-url-params (if (and (= method "GET") (nil? url-params))
+                              params
+                              url-params)]
     (str uri
          (if (re-find #"\?" uri) "&" "?")                   ; add & if uri contains ?
          (url/params-to-str vec-strategy final-url-params))

--- a/src/ajax/interceptors.cljc
+++ b/src/ajax/interceptors.cljc
@@ -187,7 +187,7 @@
 ;;; Its function is to rewrite the uri of GET requests,
 ;;; since there's no other way to transmit params data
 ;;; in a GET.
-(defrecord ProcessGet []
+(defrecord ProcessUrlParameters []
   Interceptor
   (-process-request [_ {:keys [method] :as request}]
     (if (= method "GET")
@@ -210,7 +210,7 @@
 
 ;;; The standard interceptors for processing a request.
 (def request-interceptors 
-  [(ProcessGet.) (DirectSubmission.) (ApplyRequestFormat.)])
+  [(ProcessUrlParameters.) (DirectSubmission.) (ApplyRequestFormat.)])
 
 ;;; It seems rubbish making a function of this, but the namespace noise
 ;;; caused by importing the actual type across boundaries is significant

--- a/src/ajax/interceptors.cljc
+++ b/src/ajax/interceptors.cljc
@@ -170,14 +170,18 @@
                    headers))))
   (-process-response [_ xhrio] xhrio))
 
-(m/defn-curried ^:internal uri-with-params [{:keys [vec-strategy params]} uri]
+(m/defn-curried ^:internal uri-with-params [{:keys [vec-strategy params method url-params]} uri]
   "Internal function. Takes a uri and appends the interpretation of the query string to it
    matching the behaviour of `url-request-format`."
-  (if params
+  (if (and (= method "GET") params)
     (str uri
          (if (re-find #"\?" uri) "&" "?") ; add & if uri contains ?
          (url/params-to-str vec-strategy params))
-    uri))
+    (if url-params
+      (str uri
+           (if (re-find #"\?" uri) "&" "?") ; add & if uri contains ?
+           (url/params-to-str vec-strategy url-params))
+      uri)))
 
 ;;; ProcessGet is one of the standard interceptors
 ;;; Its function is to rewrite the uri of GET requests,
@@ -189,7 +193,8 @@
     (if (= method "GET")
       (reduced (update request :uri
                        (uri-with-params request)))
-      request))
+      (update request :uri
+              (uri-with-params request))))
   (-process-response [_ response] response))
 
 ;;; DirectSubmission is one of the default interceptors.

--- a/test/ajax/test/core.cljc
+++ b/test/ajax/test/core.cljc
@@ -310,6 +310,19 @@
               :body "BODY"}
              (read-fn response))))))
 
+(deftest url-params-test
+  "Sending a delete request with URL params should populate the URL with
+  the appropriate query string. Body should have null string"
+  (let [{:keys [uri body]}
+        (process-inputs {:url-params {:a 3 :b "hello"}
+                         :headers nil
+                         :uri "/test"
+                         :method "DELETE"
+                         :format (json-request-format)
+                         :response-format (json-response-format)})]
+    (is (= "/test?a=3&b=hello" uri))
+    (is (= (as-string body) "null"))))
+
 #_ (deftest empty-response
   (let [r1 (atom "whatever")
         response (FakeXhrIo. nil nil 200)]

--- a/test/ajax/test/core.cljc
+++ b/test/ajax/test/core.cljc
@@ -323,6 +323,18 @@
     (is (= "/test?a=3&b=hello" uri))
     (is (= (as-string body) "null"))))
 
+(deftest get-priority-test
+  "If a GET request is given both params and url-params, url-params takes priority."
+  (let [{:keys [uri]}
+        (process-inputs {:url-params {:a 7 :b "bye"}
+                         :params {:a 3 :b "hello"}
+                         :headers nil
+                         :uri "/test"
+                         :method "GET"
+                         :format (json-request-format)
+                         :response-format (edn-response-format)})]
+    (is (= "/test?a=7&b=bye" uri))))
+
 #_ (deftest empty-response
   (let [r1 (atom "whatever")
         response (FakeXhrIo. nil nil 200)]


### PR DESCRIPTION
Added a :url-params field. Parameters in this field always get added to the url. The only exception is get requests. Get requests add the parameters from :params to the url. This is so that we don't break current functionality.

Also added some test coverage.

This adds functionality discussed in #216 