### PR TITLE
Replace use of js->clj with transit/read

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,7 @@
                  [org.apache.httpcomponents/httpcore "4.4.6"]
                  [org.clojure/clojure "1.8.0"]
                  [org.clojure/clojurescript "1.9.854" :scope "provided"]
+                 [com.cognitect/transit-cljs "0.8.256"]
                  [lein-doo "0.1.7" :scope "test"]
                  [org.clojure/core.async "0.3.443" :scope "test"]]
   :plugins [[lein-doo "0.1.7"]

--- a/src/ajax/goog_json.cljc
+++ b/src/ajax/goog_json.cljc
@@ -1,7 +1,10 @@
 (ns ajax.goog-json
-    (:require [ajax.json :as json]
+  (:require [ajax.json :as json]
+            [ajax.util :as u]
             #?@ (:cljs [[goog.json :as goog-json]
-                        [goog.json.Serializer]])))
+                        [goog.json.Serializer]
+                        [cognitect.transit :as transit]
+                        [clojure.walk :as walk]])))
 
 #? (:cljs (defn write-json-google [data]
             (.serialize (goog.json.Serializer.) (clj->js data))))
@@ -9,11 +12,14 @@
 #? (:cljs (defn read-json-google [raw keywords? text]
             (let [json (goog-json/parse text)]
               (if raw
-                  json
-                  (js->clj json :keywordize-keys keywords?)))))
+                json
+                (let [edn (transit/read (transit/reader :json) text) ]
+                  (if keywords?
+                    (walk/keywordize-keys edn)
+                    edn))))))
 
 (def goog-json-response-format
-  "Returns a JSON response format using the native JSON 
+  "Returns a JSON response format using the native JSON
    implementation. Options include
    :keywords? Returns the keys as keywords
    :prefix A prefix that needs to be stripped off.  This is to
@@ -21,9 +27,9 @@
    you should think about using this.
    http://stackoverflow.com/questions/2669690/why-does-google-prepend-while1-to-their-json-responses
    http://haacked.com/archive/2009/06/24/json-hijacking.aspx"
-    (json/make-json-response-format 
-        #? (:clj json/read-json-cheshire :cljs read-json-google)))
+  (json/make-json-response-format
+   #? (:clj json/read-json-cheshire :cljs read-json-google)))
 
-(def goog-json-request-format 
-    (json/make-json-request-format 
-        #? (:clj json/write-json-cheshire :cljs write-json-google)))
+(def goog-json-request-format
+  (json/make-json-request-format
+   #? (:clj json/write-json-cheshire :cljs write-json-google)))

--- a/src/ajax/util.cljc
+++ b/src/ajax/util.cljc
@@ -1,10 +1,10 @@
 (ns ajax.util
-  "Short utility functions. A lot of these only exist because the 
+  "Short utility functions. A lot of these only exist because the
    cross platform implementation is annoying."
-   (:require [ajax.protocols :as pr])
-   #? (:clj
-       (:import [java.io OutputStreamWriter]
-                [java.lang String])))
+  (:require [ajax.protocols :as pr])
+  #? (:clj
+      (:import [java.io OutputStreamWriter]
+               [java.lang String])))
 
 (defn throw-error [args]
   "Throws an error."


### PR DESCRIPTION
I left one instance of js->clj in xhrio.cljs since it will only work on http headers, which I think are immune to this issue. I wanted to make the footprint of the pull request as small as possible.

Fixes #219