### PR TITLE
Support Google Closure's full list of successful response codes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,22 @@
+## Version 0.8
+
+**Breaking Changes**
+
+* The criteria for a response to be considered successful has changed.
+
+  - Previously any status from 200-299 was considered successful. If you relied
+    on 203, 205 or 207+ being successful, you may need to adjust your client
+    code.
+  - Now only those statuses specified by Google's Closure Library are
+    considered successful. Those are:
+    - 200 Ok
+    - 201 Created
+    - 202 Accepted
+    - 204 No Content
+    - 206 Partial Content
+    - 304 Not Modified
+    - 1223 QUIRK_IE_NO_CONTENT (a special case supported by Closure)
+
 ## Version 0.7
 
 * Submitting a `GET` with `:params {:a [10 20]}` used to produce `?a=10&a=20` in 0.3, it now does so again. I'd like to apologise to everyone for this particular breakage, and for the long time it's taken to fix. I know a lot of people have had to work around this issue.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cljs-ajax "0.7.5"
+(defproject cljs-ajax "0.8.0"
   :min-lein-version "2.5.2" ;;; lower can't run tests in cljc
   :description "A simple Ajax library for ClojureScript"
   :url "https://github.com/JulianBirch/cljs-ajax"

--- a/src/ajax/util.cljc
+++ b/src/ajax/util.cljc
@@ -26,6 +26,20 @@
                (.write ^String (to-str params))
                (.flush)))))
 
+(def successful-response-codes-set
+  "A set of successful response types derived from `goog.net.HttpStatus.isSuccess`."
+  ;; Factoid: Closure considers some 2XX status codes to *not* be successful, namely
+  ;; 205 Reset Content, 207 Multi Status & the unspecified 208+ range
+  #{200    ;; Ok
+    201    ;; Created
+    202    ;; Accepted
+    204    ;; No Content
+    206    ;; Partial Content
+    304    ;; Not Modified
+    ;; See https://github.com/google/closure-library/blob/f999480c4005641d284b86d82d0d5d0f05f3ffc8/closure/goog/net/httpstatus.js#L89-L94
+    1223}) ;; QUIRK_IE_NO_CONTENT
+
 (defn success? [status]
   "Indicates whether an HTTP status code is considered successful."
-  (<= 200 status 299))
+  (contains? successful-response-codes-set
+             status))


### PR DESCRIPTION
As discussed in #225, I've prepared a PR that considers responses of `304 Not Modified` (and `1223`... IE Quirk they support) as successful.

I was hesitant to reduce `success?`s surface area by removing `(<= 200 status 299)`, because it would be a large breaking change for folks. Do you think it is also a breaking change changing how 304 responses are handled by cljs.ajax? Regardless, I've peppered the source with a lot of comments and information on the topic to avoid any painful regressions.