### PR TITLE
support sets as params values

### DIFF
--- a/src/ajax/url.cljc
+++ b/src/ajax/url.cljc
@@ -100,7 +100,7 @@
             (map? value)
             (mapcat recurse (seq value)) ; {:b {:a 1}} should be ["b[a]" 1]
 
-            (sequential? value) ; behaviour depends on vec-key-transform
+            (or (sequential? value) (set? value)) ; behaviour depends on vec-key-transform
             (->> (seq value)
                  (map-indexed vec-key-transform)
                  (mapcat recurse))

--- a/test/ajax/test/runner.cljs
+++ b/test/ajax/test/runner.cljs
@@ -1,5 +1,7 @@
 (ns ajax.test.runner
   (:require [doo.runner :refer-macros [doo-tests]]
-            [ajax.test.core]))
+            [ajax.test.core]
+            [ajax.test.url]))
 
-(doo-tests 'ajax.test.core)
+(doo-tests 'ajax.test.core
+           'ajax.test.url)

--- a/test/ajax/test/url.cljc
+++ b/test/ajax/test/url.cljc
@@ -15,24 +15,27 @@
 
 (deftest params-to-str-indexed
   (is (= "b[0]=1&b[1]=2" (params-to-str :indexed {:b [1 2]})))
-  (is (= "a=0&b[0]=1&b[1]=2&c[d]=3&c[e]=4&f=5"
+  (is (= "a=0&b[0]=1&b[1]=2&c[d]=3&c[e]=4&f=5&g[0]=1"
          (params-to-str :indexed {:a 0
                                   :b [1 2]
                                   :c {:d 3 :e 4}
-                                  "f" 5}))))
+                                  "f" 5
+                                  :g #{1}}))))
 
 (deftest params-to-str-java
   (is (= "b=1&b=2" (params-to-str :java {:b [1 2]})))
-  (is (= "a=0&b=1&b=2&c[d]=3&c[e]=4&f=5"
+  (is (= "a=0&b=1&b=2&c[d]=3&c[e]=4&f=5&g=1"
          (params-to-str :java {:a 0
                                :b [1 2]
                                :c {:d 3 :e 4}
-                               "f" 5}))))
+                               "f" 5
+                               :g #{1}}))))
 
 (deftest params-to-str-rails
   (is (= "b[]=1&b[]=2" (params-to-str :rails {:b [1 2]})))
-  (is (= "a=0&b[]=1&b[]=2&c[d]=3&c[e]=4&f=5"
+  (is (= "a=0&b[]=1&b[]=2&c[d]=3&c[e]=4&f=5&g[]=1"
          (params-to-str :rails {:a 0
                                 :b [1 2]
                                 :c {:d 3 :e 4}
-                                "f" 5}))))
+                                "f" 5
+                                :g #{1}}))))


### PR DESCRIPTION
sets as params values are not handled correctly and result in badly formatted request uri. This PR handles sets as seqs. Also included the ajax.test.url ns into cljs tests.