### PR TITLE
Specify java distribution to fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: clojure
 lein: lein
+dist: xenial
+jdk:
+  - openjdk8
 before_script:
   - "yes | sudo lein upgrade 2.5.2"
 sudo: required


### PR DESCRIPTION
Hello @JulianBirch 
Not sure what your plans are for supporting versions post Java 8 but...
I found out Travis now require specifying the Java version to avoid defaulting to the "latest".
This PR simply fixes the build in the meantime 😃

Thanks
Peter