### PR TITLE
Set timeout on goog.net.XhrManager

### DIFF
--- a/src/ajax/xhrio.cljs
+++ b/src/ajax/xhrio.cljs
@@ -50,5 +50,7 @@
                   id timeout priority max-retries]
            :or {timeout 0}}
      handler]
-    (.send this id uri method body (clj->js headers)
-           priority handler max-retries)))
+    (doto this
+      (.setTimeoutInterval timeout)
+      (.send id uri method body (clj->js headers)
+             priority handler max-retries))))


### PR DESCRIPTION
`timeout` is currently unused.