### PR TITLE
fix: docstring misplacement

### DIFF
--- a/src/ajax/formats.cljc
+++ b/src/ajax/formats.cljc
@@ -25,9 +25,10 @@
 #? (:clj
     ;;; http://stackoverflow.com/questions/309424/read-convert-an-inputstream-to-a-string
     (do
-      (defn response-to-string [response]
+      (defn response-to-string
         "Interprets the response as text (a string). Isn't likely 
          to give you a good outcome if the response wasn't text."
+        [response]
         (let [s (doto (Scanner. ^InputStream (pr/-body response)
                                 "UTF-8")
                   (.useDelimiter "\\A"))]


### PR DESCRIPTION
while going over function structure in [Professional Clojurescript](https://cljs.pro/) we noticed this library had some of the docstrings in the wrong place, where they should be after function definition before parameters.