### PR TITLE
[Minor Fix] Docstring misplacement

### DIFF
--- a/src/ajax/apache.clj
+++ b/src/ajax/apache.clj
@@ -23,10 +23,11 @@
 
 (def array-of-bytes-type (Class/forName "[B"))
 
-(defn- to-entity [b]
+(defn- to-entity 
   "This function means you can just hand cljs-ajax a byte
    array, string, normal Java file or input stream and it
    will automatically work with the Apache implementation."
+  [b]
   (condp instance? b
     array-of-bytes-type (ByteArrayEntity. b)
     String (StringEntity. ^String b "UTF-8")
@@ -81,10 +82,11 @@
   (proxy [HttpEntityEnclosingRequestBase] []
     (getMethod [] method)))
 
-(defn- cancel [handler]
+(defn- cancel 
   "This method ensures that the behaviour of the wrapped
    Apache classes matches the behaviour the javascript version,
    including the negative status number."
+  [handler]
   (handler
    (map->Response {:status -1
                    :status-text "Cancelled"
@@ -102,9 +104,10 @@
                      :exception ex
                      :was-aborted false}))))
 
-(defn- create-handler [handler]
-  "Takes a cljs-ajax style handler method and converts it
+(defn- create-handler 
+   "Takes a cljs-ajax style handler method and converts it
    to a FutureCallback suitable for use the Apache API."
+  [handler]
   (reify
     FutureCallback
     (cancelled [_]
@@ -202,11 +205,11 @@
         (to-clojure-future (.execute client request h) client))
       (catch Exception ex (fail handler ex)))))
 
-(defn new-api []
+(defn new-api
   "This is the only thing exposed by the apache.clj file:
    a factory function that returns a class that wraps the
    Apache async API to the cljs-ajax API.
    Note that it's completely stateless: all of the relevant
    implementation objects are created each time."
-
+  []
   (Connection.))

--- a/src/ajax/core.cljc
+++ b/src/ajax/core.cljc
@@ -29,8 +29,9 @@
 
 (def to-interceptor i/to-interceptor)
 
-(defn abort [this]
+(defn abort 
   "Call this on the result of `ajax-request` to cancel the request."
+  [this]
   (pr/-abort this))
 
 ;;; Standard Formats

--- a/src/ajax/easy.cljc
+++ b/src/ajax/easy.cljc
@@ -19,9 +19,10 @@
   ([] (f/detect-response-format {:response-format @default-formats}))
   ([opts] (f/detect-response-format opts)))
 
-(defn keyword-request-format [format format-params]
+(defn keyword-request-format 
   "Converts an easy API request format specifier to an `ajax-request`
   request format specifier."
+  [format format-params]
   (cond
    (map? format) format
    (fn? format) {:write format}
@@ -51,11 +52,12 @@
            :detect (detect-response-format)
            nil)))
 
-(defn keyword-response-format [format format-params]
+(defn keyword-response-format 
   "Converts an easy API format specifier to an `ajax-request`
    format specifier. Mostly this is just a case of replacing `:json`
    with `json-response-format`. However, it gets complex when you
    specify a detection format such as `[[\"application/madeup\" :json]]`."
+  [format format-params]
   (if (vector? format)
     (->> format
          (map #(keyword-response-format-element % format-params))
@@ -93,13 +95,12 @@
       (when (fn? finally)
         (finally)))))
 
-(defn transform-opts [{:keys [method format response-format
-                              params body]
-                       :as opts}]
+(defn transform-opts 
   "Note that if you call GET, POST et al, this function gets
    called and will include Transit code in your JS.
    If you don't want this to happen, use ajax-request directly
    (and use advanced optimisation)."
+  [{:keys [method format response-format params body] :as opts}]
   (let [needs-format (and (nil? body) (not= method "GET"))
         rf (if (or format needs-format)
              (keyword-request-format format opts))]

--- a/src/ajax/formats.cljc
+++ b/src/ajax/formats.cljc
@@ -45,7 +45,7 @@
 
 ;;; Detect Response Format
 
-(defn get-format [request format-entry]
+(defn get-format 
   "Converts one of a number of types to a response format.
    Note that it processes `[text format]` the same as `format`,
    which makes it easier to work with detection vectors such as
@@ -53,6 +53,7 @@
    
    It also supports providing formats as raw functions. I don't 
    know if anyone has ever used this."
+  [request format-entry]
   (cond
    (or (nil? format-entry) (map? format-entry))
    format-entry
@@ -102,12 +103,13 @@
   (let [formats (if (vector? response-format) response-format [response-format])]
     (mapcat #(get-accept-entries request %) formats)))
 
-(defn detect-response-format [opts]
-    "NB This version of the response format doesn't have a zero
+(defn detect-response-format 
+   "NB This version of the response format doesn't have a zero
      arity version. This is because it would involve pulling
      in every dependency. Instead, core.cljc adds it in."
-     (let [accept (accept-header opts)]
-       (i/map->ResponseFormat
-        {:read (detect-response-format-read opts)
-         :format (str "(from " accept ")")
-         :content-type accept})))
+  [opts]
+    (let [accept (accept-header opts)]
+      (i/map->ResponseFormat
+      {:read (detect-response-format-read opts)
+        :format (str "(from " accept ")")
+        :content-type accept})))

--- a/src/ajax/interceptors.cljc
+++ b/src/ajax/interceptors.cljc
@@ -38,11 +38,12 @@
   (-process-response [{:keys [response]} xhrio]
     (response xhrio)))
 
-(defn to-interceptor [m]
-  "Utility function. If you want to create your own interceptor
+(defn to-interceptor 
+   "Utility function. If you want to create your own interceptor
    quickly, this will do the job. Note you don't need to specify
    both methods. (Or indeed either, but it won't do much under
    those circumstances.)"
+  [m]
   (map->StandardInterceptor (merge
                              {:request identity :response identity}
                              m)))
@@ -92,14 +93,16 @@
 ;;; Note that the "response format" functions all return ResponseFormat returns.
 (defrecord ResponseFormat [read description content-type]
   Interceptor
-  (-process-request [{:keys [content-type]} request]
-    "Sets the headers on the request"
+  (-process-request
+   "Sets the headers on the request" 
+   [{:keys [content-type]} request]
     (update request
             :headers
             #(merge {"Accept" (content-type-to-request-header content-type)}
                     (or % {}))))
-  (-process-response [{:keys [read] :as format} xhrio]
+  (-process-response
     "Transforms the raw response (an implementation of AjaxResponse)"
+   [{:keys [read] :as format} xhrio]
     (try
       (let [status #? (:clj (long (-status xhrio))
                        :cljs (-status xhrio))
@@ -133,12 +136,13 @@
 ;;;
 ;;; Contrast with ResponseFormat, that has to change the request to add
 ;;; the Accept header, and then transforms the response to interpret the result.
-(defn ^:internal get-request-format [format]
+(defn ^:internal get-request-format 
   "Internal function. Takes whatever was provided as :request-format and 
    converts it to a true request format. In practice, this just means it will 
    interpret functions as formats and not change maps. Note that it throws an
    exception when passed a keyword, because they should already have been 
    transformed to maps."
+  [format]
   (cond
    (map? format) format
    (keyword? format) (u/throw-error ["keywords are not allowed as request formats in ajax calls: " format])
@@ -170,9 +174,10 @@
                    headers))))
   (-process-response [_ xhrio] xhrio))
 
-(defn ^:internal uri-with-params [{:keys [vec-strategy params method url-params]} uri]
+(defn ^:internal uri-with-params 
   "Internal function. Takes a uri and appends the interpretation of the query string to it
    matching the behaviour of `url-request-format`."
+  [{:keys [vec-strategy params method url-params]} uri]
   (if-let [final-url-params (if (and (= method "GET") (nil? url-params))
                               params
                               url-params)]

--- a/src/ajax/json.cljc
+++ b/src/ajax/json.cljc
@@ -61,8 +61,9 @@
                (.substring text (.-length prefix))
                text)))
 
-(defn make-json-response-format [read-json]
+(defn make-json-response-format 
   "Create a json request format given `read-json` function."
+  [read-json]
   (fn json-response-format
     ([] (json-response-format {}))
     ([{:keys [prefix keywords? raw]}]

--- a/src/ajax/simple.cljc
+++ b/src/ajax/simple.cljc
@@ -51,12 +51,14 @@
   #? (:clj  (a/new-api)
       :cljs (new goog.net.XhrIo)))
 
-(defn process-request [request interceptor]
+(defn process-request 
   "-process-request with the arguments flipped for use in reduce"
+  [request interceptor]
   (pr/-process-request interceptor request))
 
-(defn raw-ajax-request [{:keys [interceptors] :as request}]
+(defn raw-ajax-request 
   "The main request function."
+  [{:keys [interceptors] :as request}]
   (let [request (reduce process-request request interceptors)
         ;;; Pass the request through the interceptors
         handler (base-handler (reverse interceptors) request)

--- a/src/ajax/url.cljc
+++ b/src/ajax/url.cljc
@@ -75,12 +75,13 @@
         (partial vec-key-transform-fn vec-key-encode)))
 
 
-(defn- param-to-key-value-pairs [vec-key-transform prefix [key value]]
-    "Takes a parameter and turns it into a sequence of key-value pairs suitable
+(defn- param-to-key-value-pairs 
+  "Takes a parameter and turns it into a sequence of key-value pairs suitable
      for passing to `key-value-pair-to-str`. Since we can have nested maps and
      vectors, we need a vec-key-transform function and the current query key
      prefix as well as the key and value to be analysed. Ultimately, this 
-     function walks the structure and flattens it." 
+     function walks the structure and flattens it."
+  [vec-key-transform prefix [key value]]
     (let [k1 (key-encode key)
           new-key (if prefix 
                       (if key 
@@ -105,11 +106,12 @@
 
             :else [[new-key value]])))
 
-(defn params-to-str [vec-strategy params]
-    "vec-strategy is one of :rails (a[]=3&a[]=4)
-                            :java (a=3&a=4) (this is the correct behaviour and the default)
-                            :indexed (a[3]=1&a[4]=1)
+(defn params-to-str 
+   "vec-strategy is one of :rails (a[]=3&a[]=4)
+                           :java (a=3&a=4) (this is the correct behaviour and the default)
+                           :indexed (a[3]=1&a[4]=1)
      params is an arbitrary clojure map"
+  [vec-strategy params]
     (->> [nil params]
          (param-to-key-value-pairs (to-vec-key-transform vec-strategy) nil)
          (map key-value-pair-to-str)

--- a/src/ajax/util.cljc
+++ b/src/ajax/util.cljc
@@ -6,20 +6,22 @@
        (:import [java.io OutputStreamWriter]
                 [java.lang String])))
 
-(defn throw-error [args]
+(defn throw-error 
   "Throws an error."
+  [args]
   (throw (#?(:clj Exception. :cljs js/Error.)
            (str args))))
 
 (defn get-content-type ^String [response]
   (or (pr/-get-response-header response "Content-Type") ""))
 
-(defn to-utf8-writer [to-str]
+(defn to-utf8-writer 
   "Takes a function that converts to a string and transforms it
    into a function that converts to an object that will write
    UTF-8 to the wire. Note that this is the identity function
    for JavaScript because the underlying implementations take
    a string."
+  [to-str]
   #? (:cljs to-str
       :clj (fn write-utf8 [stream params]
              (doto (OutputStreamWriter. stream)
@@ -39,7 +41,8 @@
     ;; See https://github.com/google/closure-library/blob/f999480c4005641d284b86d82d0d5d0f05f3ffc8/closure/goog/net/httpstatus.js#L89-L94
     1223}) ;; QUIRK_IE_NO_CONTENT
 
-(defn success? [status]
+(defn success? 
   "Indicates whether an HTTP status code is considered successful."
+  [status]
   (contains? successful-response-codes-set
              status))


### PR DESCRIPTION
While digging through the code for issues I was encountering, I noticed some docstring misplacements. 

Shout out to the [Professional ClojureScript](https://cljs.pro/) class. It was repeated that docstring goes before the arguments 💯 