### PR TITLE
Return headers with a 204 response

### DIFF
--- a/src/ajax/goog_json.cljc
+++ b/src/ajax/goog_json.cljc
@@ -7,10 +7,12 @@
             (.serialize (goog.json.Serializer.) (clj->js data))))
 
 #? (:cljs (defn read-json-google [raw keywords? text]
-            (let [json (goog-json/parse text)]
-              (if raw
-                  json
-                  (js->clj json :keywordize-keys keywords?)))))
+            (if (empty? text)
+                nil
+                (let [json (goog-json/parse text)]
+                  (if raw
+                    json
+                    (js->clj json :keywordize-keys keywords?))))))
 
 (def goog-json-response-format
   "Returns a JSON response format using the native JSON 

--- a/src/ajax/interceptors.cljc
+++ b/src/ajax/interceptors.cljc
@@ -114,7 +114,6 @@
           -1 (if (-was-aborted xhrio)
                (fail "Request aborted by client." :aborted)
                (fail "Request timed out." :timeout))
-          204 [true nil]       ; 204 and 205 should have empty responses
           205 [true nil]
           (try
             (let [response (read xhrio)]

--- a/src/ajax/json.cljc
+++ b/src/ajax/json.cljc
@@ -27,10 +27,12 @@
            (c/parse-stream (io/reader text) keywords?)))
 
 #? (:cljs (defn read-json-native [raw keywords? text]
-               (let [result-raw (.parse js/JSON text)]
-                    (if raw
-                        result-raw
-                        (js->clj result-raw :keywordize-keys keywords?)))))
+            (if (empty? text)
+              nil
+              (let [result-raw (.parse js/JSON text)]
+                (if raw
+                  result-raw
+                  (js->clj result-raw :keywordize-keys keywords?))))))
 
 ; From Kjetil Thuen's "safe" converter
 #? (:cljs (defn read-json-transit [raw keywords? text]


### PR DESCRIPTION
While responses with status code 204 should not return content, the headers are still useful to read. This fixes https://github.com/JulianBirch/cljs-ajax/issues/251 and still processes the response, returning a `nil` body.