### PR TITLE
Give some little more clues around why EDN isn't available by default

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -68,7 +68,7 @@ the `:ring` keyword.)
 
 ### EDN
 
-EDN is deprecated, but the functions `edn-request-format` and `edn-response-format` are available in the `ajax.edn` namespace.
+EDN is deprecated as a default available format (see issue [#54](https://github.com/JulianBirch/cljs-ajax/issues/54)), but the functions `edn-request-format` and `edn-response-format` are available in the `ajax.edn` namespace.
 
 ### Google Closure JSON
 


### PR DESCRIPTION
Hi! Thanks for this awesome library!

I was looking for EDN response format support and found it mentioned in the docs, including how to to do it. So that's all fine. However, it left me wondering about why it was deprecated, so I browsed the issues and found it, including attempts to reinstall it. 😄  I'm hoping my change can help people to more quickly understand why EDN is opt in.

My use case (in case anyone wonders why I would be using EDN transport, like a crazy person) is that I often mock a “server“ by adding data files to the public directory and fetch them from there. That way I can keep my frontend app free of infrastructure dependencies while it is in the beginning phases. The server will most often be using transit when it is there, and this EDN mock is easy to replace with the real thing.