### PR TITLE
Migrate the JVM implementation to Apache HttpClient 5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,18 @@
 
 **Breaking Changes**
 
+* The JVM implementation now uses Apache HttpClient 5 instead of Apache
+  HttpAsyncClient 4, which reached end of life. The dependency changes from
+  `org.apache.httpcomponents/httpasyncclient` to
+  `org.apache.httpcomponents.client5/httpclient5`; anything that pinned or
+  excluded the old coordinates needs updating.
+* `:cookie-policy` values are mapped onto the cookie specifications HttpClient
+  5 provides. It only ships RFC 6265, so `:default`, `:netscape` and
+  `:standard` all select the relaxed RFC 6265 policy and `:standard-strict`
+  selects the strict one. The Netscape draft specification no longer exists.
+* A connect timeout now also reports a status of `-1` and a `:failure` of
+  `:timeout`, matching what a socket timeout has always reported.
+
 * Empty JSON, EDN and Transit response bodies now decode to
   `ajax.core/empty-response`, irrespective of HTTP status. This distinguishes
   an absent response body from encoded nil/null values such as JSON `null` or

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ simple Ajax client for ClojureScript and Clojure
 [![Release](https://github.com/JulianBirch/cljs-ajax/actions/workflows/release.yml/badge.svg)](https://github.com/JulianBirch/cljs-ajax/actions/workflows/release.yml)
 [![Clojars](https://img.shields.io/clojars/v/cljs-ajax.svg)](https://clojars.org/cljs-ajax)
 
-`cljs-ajax` exposes the same interface (where useful) in both Clojure and ClojureScript. On ClojureScript it operates as a wrapper around [`goog.net.XhrIo`](https://developers.google.com/closure/library/docs/xhrio?hl=en) or [`js/XmlHttpRequest`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest), while on the JVM it's a wrapper around the [Apache HttpAsyncClient](https://hc.apache.org/httpcomponents-asyncclient-4.1.x/index.html) library. 
+`cljs-ajax` exposes the same interface (where useful) in both Clojure and ClojureScript. On ClojureScript it operates as a wrapper around [`goog.net.XhrIo`](https://developers.google.com/closure/library/docs/xhrio?hl=en) or [`js/XmlHttpRequest`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest), while on the JVM it's a wrapper around the [Apache HttpClient](https://hc.apache.org/httpcomponents-client-5.6.x/index.html) asynchronous API. 
 
 In addition to this document, there's an [FAQ](docs/faq.md), a [change log](CHANGES.md) and a [contribution document](CONTRIBUTING.md). Furthermore, there is detailed documentation on specific features and design advice in the [docs folder](docs).
 
@@ -39,7 +39,7 @@ The `GET`, `POST`, and `PUT` helpers accept a URI followed by a map of options:
 * `:url-params` - parameters that will be added onto query string. In the case of a GET request, parameters defined here will replace parameters defined in `:params`.
 * `:timeout` - the ajax call's timeout in milliseconds.  Default is `0` (no timeout).
 * `:headers` - a map of the HTTP headers to set with the request
-* `:cookie-policy` - a keyword for the cookie management specification. **Only available in Java**. Optional. One of `:none`, `:default`, `:netscape`, `:standard`, `:standard-strict`.
+* `:cookie-policy` - a keyword for the cookie management specification. **Only available in Java**. Optional. One of `:none`, `:default`, `:netscape`, `:standard`, `:standard-strict`. Apache HttpClient 5 only ships the RFC 6265 specifications, so `:default`, `:netscape` and `:standard` all select the relaxed RFC 6265 policy, and `:standard-strict` selects the strict one.
 
 * `:with-credentials` - a boolean, whether to set the `withCredentials` flag on the XHR object.
 * `:body` the exact data to send with in the request. If specified, both `:params` and `:request-format` are ignored.  Note that you can submit js/FormData and other "raw" javascript types through this.
@@ -188,7 +188,7 @@ The following parameters are the same as in the `GET`/`POST` easy api:
 * `:params` - the parameters that will be sent with the request,  format dependent: `:transit` and `:edn` can send anything, `:json` and `:raw` need to be given a map.  `GET` will add params onto the query string, `POST` will put the params in the body
 * `:timeout` - the ajax call's timeout.  30 seconds if left blank
 * `:headers` - a map of the HTTP headers to set with the request
-* `:cookie-policy` - a keyword for the cookie management specification. **Only available in Java**. Optional. One of `:none`, `:default`, `:netscape`, `:standard`, `:standard-strict`.
+* `:cookie-policy` - a keyword for the cookie management specification. **Only available in Java**. Optional. One of `:none`, `:default`, `:netscape`, `:standard`, `:standard-strict`. Apache HttpClient 5 only ships the RFC 6265 specifications, so `:default`, `:netscape` and `:standard` all select the relaxed RFC 6265 policy, and `:standard-strict` selects the strict one.
 * `:with-credentials` - a boolean, whether to set the `withCredentials` flag on the XHR object.
 * `:interceptors` - the [interceptors](docs/interceptors.md) to run for this request. If not set, runs contents of the `default-interceptors` global atom. This is an empty vector by default. For more information, visit the [interceptors page](docs/interceptors.md).
 

--- a/deps.edn
+++ b/deps.edn
@@ -3,8 +3,8 @@
  :deps {cheshire/cheshire {:mvn/version "5.10.0"}
         com.cognitect/transit-clj {:mvn/version "1.0.324"}
         com.cognitect/transit-cljs {:mvn/version "0.8.264"}
-        org.apache.httpcomponents/httpasyncclient {:mvn/version "4.1.4"}
-        org.apache.httpcomponents/httpcore {:mvn/version "4.4.14"}
+        org.apache.httpcomponents.client5/httpclient5 {:mvn/version "5.6.1"}
+        org.apache.httpcomponents.core5/httpcore5 {:mvn/version "5.4.2"}
         org.clojure/clojure {:mvn/version "1.11.1"}}
  :aliases
  {:test {:extra-paths ["test" "support"]

--- a/src/ajax/apache.clj
+++ b/src/ajax/apache.clj
@@ -1,20 +1,32 @@
 (ns ajax.apache
   (:require [ajax.protocols :refer [map->Response
               AjaxImpl AjaxRequest AjaxResponse]]
+            [clojure.java.io :as io]
             [clojure.string :as s])
   (:import [clojure.lang IDeref IBlockingDeref IPending]
-           [org.apache.http HttpResponse Header]
-           [org.apache.http.entity ByteArrayEntity StringEntity
-            FileEntity InputStreamEntity]
-           [org.apache.http.client.methods HttpRequestBase
-            HttpEntityEnclosingRequestBase]
-           [org.apache.http.client.config RequestConfig CookieSpecs]
-           [org.apache.http.concurrent FutureCallback]
-           [org.apache.http.impl.nio.client HttpAsyncClients]
+           [org.apache.hc.client5.http ConnectTimeoutException]
+           [org.apache.hc.client5.http.async.methods SimpleHttpResponse
+            SimpleResponseConsumer]
+           [org.apache.hc.client5.http.config ConnectionConfig RequestConfig]
+           [org.apache.hc.client5.http.cookie StandardCookieSpec]
+           [org.apache.hc.client5.http.impl.async CloseableHttpAsyncClient
+            HttpAsyncClients]
+           [org.apache.hc.client5.http.impl.nio
+            PoolingAsyncClientConnectionManagerBuilder]
+           [org.apache.hc.core5.concurrent FutureCallback]
+           [org.apache.hc.core5.http ContentType Header]
+           [org.apache.hc.core5.http.nio AsyncEntityProducer
+            AsyncRequestProducer]
+           [org.apache.hc.core5.http.nio.entity AsyncEntityProducers]
+           [org.apache.hc.core5.http.nio.support AsyncRequestBuilder]
+           [org.apache.hc.core5.http.nio.support.classic
+            AbstractClassicEntityProducer]
+           [org.apache.hc.core5.util Timeout]
            [java.lang Exception]
            [java.util.concurrent Future]
            [java.net URI SocketTimeoutException]
-           [java.io File InputStream Closeable]))
+           [java.io ByteArrayInputStream File InputStream OutputStream
+            Closeable]))
 
 ;;; Chunks of this code liberally ripped off dakrone/clj-http
 ;;; Although that uses the synchronous API
@@ -23,16 +35,28 @@
 
 (def array-of-bytes-type (Class/forName "[B"))
 
-(defn- to-entity 
+(def ^:private ^ContentType text-content-type
+  (ContentType/create "text/plain" "UTF-8"))
+
+(defn- stream-entity-producer
+  "HttpClient 5 has no entity producer for an InputStream, so we use
+   the classic (blocking) producer, which pumps the stream on a
+   separate thread rather than buffering it in memory."
+  ^AsyncEntityProducer [^InputStream in]
+  (proxy [AbstractClassicEntityProducer] [8192 nil clojure.lang.Agent/soloExecutor]
+    (produceData [_content-type ^OutputStream out]
+      (io/copy in out))))
+
+(defn- to-entity-producer
   "This function means you can just hand cljs-ajax a byte
    array, string, normal Java file or input stream and it
    will automatically work with the Apache implementation."
-  [b]
+  ^AsyncEntityProducer [b]
   (condp instance? b
-    array-of-bytes-type (ByteArrayEntity. b)
-    String (StringEntity. ^String b "UTF-8")
-    File (FileEntity. b)
-    InputStream (InputStreamEntity. b)
+    array-of-bytes-type (AsyncEntityProducers/create ^bytes b nil)
+    String (AsyncEntityProducers/create ^String b text-content-type)
+    File (AsyncEntityProducers/create ^File b nil)
+    InputStream (stream-entity-producer b)
     b))
 
 (defn- to-uri [u]
@@ -49,40 +73,46 @@
 ;;; So, you end up doing what you'd normally do in Java,
 ;;; write an adapter class.
 
-;;; Takes an HttpResponse and exposes the interface needed
+;;; Takes a SimpleHttpResponse and exposes the interface needed
 ;;; by cljs-ajax interceptors (including response formats).
 
-(defrecord HttpResponseWrapper [^HttpResponse response]
+(defrecord HttpResponseWrapper [^SimpleHttpResponse response]
   AjaxResponse
   (-body [this]
-    (let [^HttpResponse response (:response this)]
-      (some-> response .getEntity .getContent)))
+    (let [^SimpleHttpResponse response (:response this)]
+      (some-> (.getBodyBytes response) (ByteArrayInputStream.))))
   (-status [this]
-    (let [^HttpResponse response (:response this)]
-      (-> response .getStatusLine .getStatusCode)))
+    (let [^SimpleHttpResponse response (:response this)]
+      (.getCode response)))
   (-status-text [this]
-    (let [^HttpResponse response (:response this)]
-      (-> response .getStatusLine .getReasonPhrase)))
+    (let [^SimpleHttpResponse response (:response this)]
+      (.getReasonPhrase response)))
   (-get-all-headers [this]
-    (let [^HttpResponse response (:response this)]
+    (let [^SimpleHttpResponse response (:response this)]
       (reduce (fn [headers ^Header header]
                 (assoc headers (.getName header) (.getValue header)))
               {}
-              (.getAllHeaders response))))
+              (.getHeaders response))))
   (-get-response-header [this header]
-    (let [^HttpResponse response (:response this)]
-      (.getValue (.getFirstHeader response header))))
+    (let [^SimpleHttpResponse response (:response this)]
+      (.getValue (.getFirstHeader response ^String header))))
   (-was-aborted [this] false))
 
 (defn- create-request
-  "Life's to short to use all of the apache types for
-   the different HTTP methods when you can just wrap a
-   string in the appropriate base class."
-  ^HttpEntityEnclosingRequestBase [method]
-  (proxy [HttpEntityEnclosingRequestBase] []
-    (getMethod [] method)))
+  "Builds the request producer the Apache async API executes.
+   `AsyncRequestBuilder` takes the method as a string, so all
+   HTTP methods are supported without a class per method."
+  ^AsyncRequestProducer [{:keys [uri method body headers]}]
+  (let [builder (AsyncRequestBuilder/create method)]
+    (.setUri builder ^URI (to-uri uri))
+    (when-let [entity (to-entity-producer body)]
+      (.setEntity builder ^AsyncEntityProducer entity))
+    (doseq [x headers]
+      (let [[h v] x]
+        (.addHeader builder ^String h ^String v)))
+    (.build builder)))
 
-(defn- cancel 
+(defn- cancel
   "This method ensures that the behaviour of the wrapped
    Apache classes matches the behaviour the javascript version,
    including the negative status number."
@@ -93,10 +123,14 @@
                    :headers {}
                    :was-aborted true})))
 
+(defn- timeout? [ex]
+  (or (instance? SocketTimeoutException ex)
+      (instance? ConnectTimeoutException ex)))
+
 (defn- fail [handler ^Exception ex]
   "XMLHttpRequest reports a status of -1 for timeouts, so
    we do the same."
-  (let [status (if (instance? SocketTimeoutException ex) -1 0)]
+  (let [status (if (timeout? ex) -1 0)]
     (handler
      (map->Response {:status status
                      :status-text (.getMessage ex)
@@ -104,7 +138,7 @@
                      :exception ex
                      :was-aborted false}))))
 
-(defn- create-handler 
+(defn- create-handler
    "Takes a cljs-ajax style handler method and converts it
    to a FutureCallback suitable for use the Apache API."
   [handler]
@@ -124,26 +158,49 @@
   (fn get-cookie-dispatch [request] (:cookie-policy request)))
 
 (defmethod get-cookie-policy :none none-cookie-policy
-  [_] CookieSpecs/IGNORE_COOKIES)
+  [_] StandardCookieSpec/IGNORE)
 (defmethod get-cookie-policy :default default-cookie-policy
-  [_] CookieSpecs/DEFAULT)
+  [_] StandardCookieSpec/RELAXED)
 (defmethod get-cookie-policy :netscape netscape-cookie-policy
-  [_] CookieSpecs/NETSCAPE)
+  [_] StandardCookieSpec/RELAXED)
 (defmethod get-cookie-policy :standard standard-cookie-policy
-  [_] CookieSpecs/STANDARD)
+  [_] StandardCookieSpec/RELAXED)
 (defmethod get-cookie-policy :standard-strict standard-strict-cookie-policy
-  [_] CookieSpecs/STANDARD_STRICT)
+  [_] StandardCookieSpec/STRICT)
+
+(defn- to-timeout
+  "Zero or absent means no timeout, matching XMLHttpRequest."
+  ^Timeout [ms]
+  (if (and ms (pos? ms))
+    (Timeout/ofMilliseconds (long ms))
+    Timeout/DISABLED))
+
+(defn- create-connection-config
+  ^ConnectionConfig [{:keys [timeout socket-timeout]}]
+  (-> (ConnectionConfig/custom)
+      (.setConnectTimeout (to-timeout timeout))
+      (.setSocketTimeout (to-timeout (or socket-timeout timeout)))
+      (.build)))
 
 (defn- create-request-config
-  ^RequestConfig [{:keys [timeout socket-timeout cookie-policy] :as req}]
+  ^RequestConfig [{:keys [cookie-policy] :as req}]
   (let [builder (RequestConfig/custom)]
-    (if timeout
-      (.setConnectTimeout builder timeout))
-    (if-let [st (or socket-timeout timeout)]
-      (.setSocketTimeout builder st))
     (if cookie-policy
-      (.setCookieSpec builder (get-cookie-policy req)))
+      (.setCookieSpec builder ^String (get-cookie-policy req)))
     (.build builder)))
+
+(defn- create-client
+  "The connection manager owns the connect and socket timeouts in
+   HttpClient 5; it is not shared, so closing the client closes it."
+  ^CloseableHttpAsyncClient [opts]
+  (let [connection-manager (-> (PoolingAsyncClientConnectionManagerBuilder/create)
+                               (.setDefaultConnectionConfig
+                                (create-connection-config opts))
+                               (.build))]
+    (-> (HttpAsyncClients/custom)
+        (.setConnectionManager connection-manager)
+        (.setDefaultRequestConfig (create-request-config opts))
+        (.build))))
 
 (defn- to-clojure-future
   "Converts a normal Java future to one similar to the one generated
@@ -188,21 +245,15 @@
 (defrecord Connection []
   AjaxImpl
   (-js-ajax-request
-    [this {:keys [uri method body headers] :as opts} handler]
+    [this opts handler]
     (try
-      (let [request (doto (create-request method)
-                      (.setURI (to-uri uri))
-                      (.setEntity (to-entity body)))
-            request-config (create-request-config opts)
-            builder (doto (HttpAsyncClients/custom)
-                      (.setDefaultRequestConfig request-config))
-            client (doto (.build builder)
-                     (.start))
-            h (create-handler handler)]
-        (doseq [x headers]
-          (let [[h v] x]
-            (.addHeader request h v)))
-        (to-clojure-future (.execute client request h) client))
+      (let [request (create-request opts)
+            ^CloseableHttpAsyncClient client (create-client opts)
+            ^FutureCallback h (create-handler handler)]
+        (.start client)
+        (to-clojure-future
+         (.execute client request (SimpleResponseConsumer/create) h)
+         client))
       (catch Exception ex (fail handler ex)))))
 
 (defn new-api


### PR DESCRIPTION
HttpAsyncClient 4 is [end of life][eol] and no longer developed or supported.
This moves the JVM implementation to HttpClient 5.

[eol]: https://hc.apache.org/httpcomponents-asyncclient-4.1.x/index.html

## What changed in `ajax.apache`

| 4.x | 5.x |
| --- | --- |
| `HttpEntityEnclosingRequestBase` proxy | `AsyncRequestBuilder/create <method>` |
| `HttpEntity` | `AsyncEntityProducer` |
| default buffering response consumer | `SimpleResponseConsumer` |
| `HttpResponse` + `.getStatusLine` | `SimpleHttpResponse` + `.getCode` |
| timeouts on `RequestConfig` | timeouts on `ConnectionConfig` |
| `CookieSpecs` (five specs) | `StandardCookieSpec` (three) |

`AsyncRequestBuilder` takes the method as a string, so arbitrary HTTP methods
still work without a class per method. `SimpleResponseConsumer` buffers the
body like the 4.x consumer did, so `-body` still returns a stream over buffered
bytes, and still `nil` when there is no body.

The dependency changes from `org.apache.httpcomponents/httpasyncclient` to
`org.apache.httpcomponents.client5/httpclient5`. Downstream code that pinned or
excluded the old coordinates needs updating; noted in CHANGES.md.

## Behaviour changes

**Cookie policies.** HttpClient 5 ships only the RFC 6265 specs, so the five
keywords no longer map one to one. `:default`, `:netscape` and `:standard`
select the relaxed policy, `:standard-strict` selects the strict one. The
Netscape draft spec is gone from the library. I kept `:netscape` accepted
rather than removing it; say if you would prefer it removed.

**Zero timeouts.** 5.x defaults the connect timeout to three minutes where 4.x
left it unbounded. An absent or zero `:timeout` maps to `Timeout/DISABLED`, so
`:timeout 0` still means no timeout.

**Connect timeouts** now report status `-1` and `:failure :timeout`, matching
socket timeouts and matching what XMLHttpRequest reports.

**Input stream bodies.** HttpClient 5 has no entity producer for an
`InputStream`. Reading the stream into a byte array would turn a streaming
upload into a buffered one, so these use `AbstractClassicEntityProducer` on
`clojure.lang.Agent`'s solo executor, the pool `future` already uses. File
bodies use `FileEntityProducer`.

## Verification

Every command in `DEVELOPMENT.md`, on Linux with Chromium:

```
clojure -X:test              36 tests, 115 assertions, 0 failures
clojure -X:integration        9 tests,  15 assertions, 0 failures
npm run test:cljs:node       33 tests,  94 assertions, 0 failures
npm run test:cljs:browser    34 tests, 0 failures
npm run test:integration     13 tests, 0 failures
clojure -T:build jar         builds
```

Existing suites pass unmodified. Tests specific to this implementation are in a
follow-up PR.
