### PR TITLE
Add property based and mutation tests for the Apache implementation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,18 @@
 
 **Breaking Changes**
 
+* The JVM implementation now uses Apache HttpClient 5 instead of Apache
+  HttpAsyncClient 4, which reached end of life. The dependency changes from
+  `org.apache.httpcomponents/httpasyncclient` to
+  `org.apache.httpcomponents.client5/httpclient5`; anything that pinned or
+  excluded the old coordinates needs updating.
+* `:cookie-policy` values are mapped onto the cookie specifications HttpClient
+  5 provides. It only ships RFC 6265, so `:default`, `:netscape` and
+  `:standard` all select the relaxed RFC 6265 policy and `:standard-strict`
+  selects the strict one. The Netscape draft specification no longer exists.
+* A connect timeout now also reports a status of `-1` and a `:failure` of
+  `:timeout`, matching what a socket timeout has always reported.
+
 * Empty JSON, EDN and Transit response bodies now decode to
   `ajax.core/empty-response`, irrespective of HTTP status. This distinguishes
   an absent response body from encoded nil/null values such as JSON `null` or

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -55,7 +55,8 @@ clojure -T:build jar
 
 Alias summary:
 
-- `clojure -X:test`: JVM tests
+- `clojure -X:test`: JVM tests, including the property based tests for the
+  Apache implementation
 - `npm run test:cljs:node`: ClojureScript tests on Node
 - `npm run test:cljs:browser`: ClojureScript tests in headless Chrome
 - `npm run test:integration`: shared JVM + dedicated Node + dedicated browser integration tests against one live local server

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -60,6 +60,8 @@ Alias summary:
 - `npm run test:cljs:node`: ClojureScript tests on Node
 - `npm run test:cljs:browser`: ClojureScript tests in headless Chrome
 - `npm run test:integration`: shared JVM + dedicated Node + dedicated browser integration tests against one live local server
+- `clojure -X:mutation`: mutation testing of the Apache implementation against
+  the property suite
 - `clojure -T:build jar`: package build
 
 ## Verified Working State

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ simple Ajax client for ClojureScript and Clojure
 [![Release](https://github.com/JulianBirch/cljs-ajax/actions/workflows/release.yml/badge.svg)](https://github.com/JulianBirch/cljs-ajax/actions/workflows/release.yml)
 [![Clojars](https://img.shields.io/clojars/v/cljs-ajax.svg)](https://clojars.org/cljs-ajax)
 
-`cljs-ajax` exposes the same interface (where useful) in both Clojure and ClojureScript. On ClojureScript it operates as a wrapper around [`goog.net.XhrIo`](https://developers.google.com/closure/library/docs/xhrio?hl=en) or [`js/XmlHttpRequest`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest), while on the JVM it's a wrapper around the [Apache HttpAsyncClient](https://hc.apache.org/httpcomponents-asyncclient-4.1.x/index.html) library. 
+`cljs-ajax` exposes the same interface (where useful) in both Clojure and ClojureScript. On ClojureScript it operates as a wrapper around [`goog.net.XhrIo`](https://developers.google.com/closure/library/docs/xhrio?hl=en) or [`js/XmlHttpRequest`](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest), while on the JVM it's a wrapper around the [Apache HttpClient](https://hc.apache.org/httpcomponents-client-5.6.x/index.html) asynchronous API. 
 
 In addition to this document, there's an [FAQ](docs/faq.md), a [change log](CHANGES.md) and a [contribution document](CONTRIBUTING.md). Furthermore, there is detailed documentation on specific features and design advice in the [docs folder](docs).
 
@@ -39,7 +39,7 @@ The `GET`, `POST`, and `PUT` helpers accept a URI followed by a map of options:
 * `:url-params` - parameters that will be added onto query string. In the case of a GET request, parameters defined here will replace parameters defined in `:params`.
 * `:timeout` - the ajax call's timeout in milliseconds.  Default is `0` (no timeout).
 * `:headers` - a map of the HTTP headers to set with the request
-* `:cookie-policy` - a keyword for the cookie management specification. **Only available in Java**. Optional. One of `:none`, `:default`, `:netscape`, `:standard`, `:standard-strict`.
+* `:cookie-policy` - a keyword for the cookie management specification. **Only available in Java**. Optional. One of `:none`, `:default`, `:netscape`, `:standard`, `:standard-strict`. Apache HttpClient 5 only ships the RFC 6265 specifications, so `:default`, `:netscape` and `:standard` all select the relaxed RFC 6265 policy, and `:standard-strict` selects the strict one.
 
 * `:with-credentials` - a boolean, whether to set the `withCredentials` flag on the XHR object.
 * `:body` the exact data to send with in the request. If specified, both `:params` and `:request-format` are ignored.  Note that you can submit js/FormData and other "raw" javascript types through this.
@@ -188,7 +188,7 @@ The following parameters are the same as in the `GET`/`POST` easy api:
 * `:params` - the parameters that will be sent with the request,  format dependent: `:transit` and `:edn` can send anything, `:json` and `:raw` need to be given a map.  `GET` will add params onto the query string, `POST` will put the params in the body
 * `:timeout` - the ajax call's timeout.  30 seconds if left blank
 * `:headers` - a map of the HTTP headers to set with the request
-* `:cookie-policy` - a keyword for the cookie management specification. **Only available in Java**. Optional. One of `:none`, `:default`, `:netscape`, `:standard`, `:standard-strict`.
+* `:cookie-policy` - a keyword for the cookie management specification. **Only available in Java**. Optional. One of `:none`, `:default`, `:netscape`, `:standard`, `:standard-strict`. Apache HttpClient 5 only ships the RFC 6265 specifications, so `:default`, `:netscape` and `:standard` all select the relaxed RFC 6265 policy, and `:standard-strict` selects the strict one.
 * `:with-credentials` - a boolean, whether to set the `withCredentials` flag on the XHR object.
 * `:interceptors` - the [interceptors](docs/interceptors.md) to run for this request. If not set, runs contents of the `default-interceptors` global atom. This is an empty vector by default. For more information, visit the [interceptors page](docs/interceptors.md).
 

--- a/deps.edn
+++ b/deps.edn
@@ -43,6 +43,17 @@
   :cljs {:extra-paths ["test" "browser-test"]
          :extra-deps {org.clojure/clojurescript {:mvn/version "1.11.132"}
                       thheller/shadow-cljs {:mvn/version "2.28.19"}}}
+  :mutation {:extra-paths ["test" "support"]
+             :extra-deps {compojure/compojure {:mvn/version "1.6.2"}
+                          fogus/ring-edn {:mvn/version "0.3.0"}
+                          hiccup/hiccup {:mvn/version "1.0.5"}
+                          http-kit/http-kit {:mvn/version "2.5.3"}
+                          javax.servlet/javax.servlet-api {:mvn/version "3.1.0"}
+                          org.clojure/core.async {:mvn/version "1.3.610"}
+                          org.clojure/test.check {:mvn/version "1.1.1"}
+                          ring-server/ring-server {:mvn/version "0.5.0"}
+                          ring-transit/ring-transit {:mvn/version "0.1.6"}}
+             :exec-fn ajax.test.mutation/run-mutation-tests}
   :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.3"}}}
   :build {:extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.10"}}
           :ns-default build}}}

--- a/deps.edn
+++ b/deps.edn
@@ -3,8 +3,8 @@
  :deps {cheshire/cheshire {:mvn/version "5.10.0"}
         com.cognitect/transit-clj {:mvn/version "1.0.324"}
         com.cognitect/transit-cljs {:mvn/version "0.8.264"}
-        org.apache.httpcomponents/httpasyncclient {:mvn/version "4.1.4"}
-        org.apache.httpcomponents/httpcore {:mvn/version "4.4.14"}
+        org.apache.httpcomponents.client5/httpclient5 {:mvn/version "5.6.1"}
+        org.apache.httpcomponents.core5/httpcore5 {:mvn/version "5.4.2"}
         org.clojure/clojure {:mvn/version "1.11.1"}}
  :aliases
  {:test {:extra-paths ["test" "support"]

--- a/deps.edn
+++ b/deps.edn
@@ -14,6 +14,7 @@
                       http-kit/http-kit {:mvn/version "2.5.3"}
                       javax.servlet/javax.servlet-api {:mvn/version "3.1.0"}
                       org.clojure/core.async {:mvn/version "1.3.610"}
+                      org.clojure/test.check {:mvn/version "1.1.1"}
                       ring-server/ring-server {:mvn/version "0.5.0"}
                       ring-transit/ring-transit {:mvn/version "0.1.6"}}
          :exec-fn ajax.test.jvm-runner/run-tests}

--- a/src/ajax/apache.clj
+++ b/src/ajax/apache.clj
@@ -1,20 +1,32 @@
 (ns ajax.apache
   (:require [ajax.protocols :refer [map->Response
               AjaxImpl AjaxRequest AjaxResponse]]
+            [clojure.java.io :as io]
             [clojure.string :as s])
   (:import [clojure.lang IDeref IBlockingDeref IPending]
-           [org.apache.http HttpResponse Header]
-           [org.apache.http.entity ByteArrayEntity StringEntity
-            FileEntity InputStreamEntity]
-           [org.apache.http.client.methods HttpRequestBase
-            HttpEntityEnclosingRequestBase]
-           [org.apache.http.client.config RequestConfig CookieSpecs]
-           [org.apache.http.concurrent FutureCallback]
-           [org.apache.http.impl.nio.client HttpAsyncClients]
+           [org.apache.hc.client5.http ConnectTimeoutException]
+           [org.apache.hc.client5.http.async.methods SimpleHttpResponse
+            SimpleResponseConsumer]
+           [org.apache.hc.client5.http.config ConnectionConfig RequestConfig]
+           [org.apache.hc.client5.http.cookie StandardCookieSpec]
+           [org.apache.hc.client5.http.impl.async CloseableHttpAsyncClient
+            HttpAsyncClients]
+           [org.apache.hc.client5.http.impl.nio
+            PoolingAsyncClientConnectionManagerBuilder]
+           [org.apache.hc.core5.concurrent FutureCallback]
+           [org.apache.hc.core5.http ContentType Header]
+           [org.apache.hc.core5.http.nio AsyncEntityProducer
+            AsyncRequestProducer]
+           [org.apache.hc.core5.http.nio.entity AsyncEntityProducers]
+           [org.apache.hc.core5.http.nio.support AsyncRequestBuilder]
+           [org.apache.hc.core5.http.nio.support.classic
+            AbstractClassicEntityProducer]
+           [org.apache.hc.core5.util Timeout]
            [java.lang Exception]
            [java.util.concurrent Future]
            [java.net URI SocketTimeoutException]
-           [java.io File InputStream Closeable]))
+           [java.io ByteArrayInputStream File InputStream OutputStream
+            Closeable]))
 
 ;;; Chunks of this code liberally ripped off dakrone/clj-http
 ;;; Although that uses the synchronous API
@@ -23,16 +35,28 @@
 
 (def array-of-bytes-type (Class/forName "[B"))
 
-(defn- to-entity 
+(def ^:private ^ContentType text-content-type
+  (ContentType/create "text/plain" "UTF-8"))
+
+(defn- stream-entity-producer
+  "HttpClient 5 has no entity producer for an InputStream, so we use
+   the classic (blocking) producer, which pumps the stream on a
+   separate thread rather than buffering it in memory."
+  ^AsyncEntityProducer [^InputStream in]
+  (proxy [AbstractClassicEntityProducer] [8192 nil clojure.lang.Agent/soloExecutor]
+    (produceData [_content-type ^OutputStream out]
+      (io/copy in out))))
+
+(defn- to-entity-producer
   "This function means you can just hand cljs-ajax a byte
    array, string, normal Java file or input stream and it
    will automatically work with the Apache implementation."
-  [b]
+  ^AsyncEntityProducer [b]
   (condp instance? b
-    array-of-bytes-type (ByteArrayEntity. b)
-    String (StringEntity. ^String b "UTF-8")
-    File (FileEntity. b)
-    InputStream (InputStreamEntity. b)
+    array-of-bytes-type (AsyncEntityProducers/create ^bytes b nil)
+    String (AsyncEntityProducers/create ^String b text-content-type)
+    File (AsyncEntityProducers/create ^File b nil)
+    InputStream (stream-entity-producer b)
     b))
 
 (defn- to-uri [u]
@@ -49,40 +73,46 @@
 ;;; So, you end up doing what you'd normally do in Java,
 ;;; write an adapter class.
 
-;;; Takes an HttpResponse and exposes the interface needed
+;;; Takes a SimpleHttpResponse and exposes the interface needed
 ;;; by cljs-ajax interceptors (including response formats).
 
-(defrecord HttpResponseWrapper [^HttpResponse response]
+(defrecord HttpResponseWrapper [^SimpleHttpResponse response]
   AjaxResponse
   (-body [this]
-    (let [^HttpResponse response (:response this)]
-      (some-> response .getEntity .getContent)))
+    (let [^SimpleHttpResponse response (:response this)]
+      (some-> (.getBodyBytes response) (ByteArrayInputStream.))))
   (-status [this]
-    (let [^HttpResponse response (:response this)]
-      (-> response .getStatusLine .getStatusCode)))
+    (let [^SimpleHttpResponse response (:response this)]
+      (.getCode response)))
   (-status-text [this]
-    (let [^HttpResponse response (:response this)]
-      (-> response .getStatusLine .getReasonPhrase)))
+    (let [^SimpleHttpResponse response (:response this)]
+      (.getReasonPhrase response)))
   (-get-all-headers [this]
-    (let [^HttpResponse response (:response this)]
+    (let [^SimpleHttpResponse response (:response this)]
       (reduce (fn [headers ^Header header]
                 (assoc headers (.getName header) (.getValue header)))
               {}
-              (.getAllHeaders response))))
+              (.getHeaders response))))
   (-get-response-header [this header]
-    (let [^HttpResponse response (:response this)]
-      (.getValue (.getFirstHeader response header))))
+    (let [^SimpleHttpResponse response (:response this)]
+      (.getValue (.getFirstHeader response ^String header))))
   (-was-aborted [this] false))
 
 (defn- create-request
-  "Life's to short to use all of the apache types for
-   the different HTTP methods when you can just wrap a
-   string in the appropriate base class."
-  ^HttpEntityEnclosingRequestBase [method]
-  (proxy [HttpEntityEnclosingRequestBase] []
-    (getMethod [] method)))
+  "Builds the request producer the Apache async API executes.
+   `AsyncRequestBuilder` takes the method as a string, so all
+   HTTP methods are supported without a class per method."
+  ^AsyncRequestProducer [{:keys [uri method body headers]}]
+  (let [builder (AsyncRequestBuilder/create method)]
+    (.setUri builder ^URI (to-uri uri))
+    (when-let [entity (to-entity-producer body)]
+      (.setEntity builder ^AsyncEntityProducer entity))
+    (doseq [x headers]
+      (let [[h v] x]
+        (.addHeader builder ^String h ^String v)))
+    (.build builder)))
 
-(defn- cancel 
+(defn- cancel
   "This method ensures that the behaviour of the wrapped
    Apache classes matches the behaviour the javascript version,
    including the negative status number."
@@ -93,10 +123,14 @@
                    :headers {}
                    :was-aborted true})))
 
+(defn- timeout? [ex]
+  (or (instance? SocketTimeoutException ex)
+      (instance? ConnectTimeoutException ex)))
+
 (defn- fail [handler ^Exception ex]
   "XMLHttpRequest reports a status of -1 for timeouts, so
    we do the same."
-  (let [status (if (instance? SocketTimeoutException ex) -1 0)]
+  (let [status (if (timeout? ex) -1 0)]
     (handler
      (map->Response {:status status
                      :status-text (.getMessage ex)
@@ -104,7 +138,7 @@
                      :exception ex
                      :was-aborted false}))))
 
-(defn- create-handler 
+(defn- create-handler
    "Takes a cljs-ajax style handler method and converts it
    to a FutureCallback suitable for use the Apache API."
   [handler]
@@ -124,26 +158,49 @@
   (fn get-cookie-dispatch [request] (:cookie-policy request)))
 
 (defmethod get-cookie-policy :none none-cookie-policy
-  [_] CookieSpecs/IGNORE_COOKIES)
+  [_] StandardCookieSpec/IGNORE)
 (defmethod get-cookie-policy :default default-cookie-policy
-  [_] CookieSpecs/DEFAULT)
+  [_] StandardCookieSpec/RELAXED)
 (defmethod get-cookie-policy :netscape netscape-cookie-policy
-  [_] CookieSpecs/NETSCAPE)
+  [_] StandardCookieSpec/RELAXED)
 (defmethod get-cookie-policy :standard standard-cookie-policy
-  [_] CookieSpecs/STANDARD)
+  [_] StandardCookieSpec/RELAXED)
 (defmethod get-cookie-policy :standard-strict standard-strict-cookie-policy
-  [_] CookieSpecs/STANDARD_STRICT)
+  [_] StandardCookieSpec/STRICT)
+
+(defn- to-timeout
+  "Zero or absent means no timeout, matching XMLHttpRequest."
+  ^Timeout [ms]
+  (if (and ms (pos? ms))
+    (Timeout/ofMilliseconds (long ms))
+    Timeout/DISABLED))
+
+(defn- create-connection-config
+  ^ConnectionConfig [{:keys [timeout socket-timeout]}]
+  (-> (ConnectionConfig/custom)
+      (.setConnectTimeout (to-timeout timeout))
+      (.setSocketTimeout (to-timeout (or socket-timeout timeout)))
+      (.build)))
 
 (defn- create-request-config
-  ^RequestConfig [{:keys [timeout socket-timeout cookie-policy] :as req}]
+  ^RequestConfig [{:keys [cookie-policy] :as req}]
   (let [builder (RequestConfig/custom)]
-    (if timeout
-      (.setConnectTimeout builder timeout))
-    (if-let [st (or socket-timeout timeout)]
-      (.setSocketTimeout builder st))
     (if cookie-policy
-      (.setCookieSpec builder (get-cookie-policy req)))
+      (.setCookieSpec builder ^String (get-cookie-policy req)))
     (.build builder)))
+
+(defn- create-client
+  "The connection manager owns the connect and socket timeouts in
+   HttpClient 5; it is not shared, so closing the client closes it."
+  ^CloseableHttpAsyncClient [opts]
+  (let [connection-manager (-> (PoolingAsyncClientConnectionManagerBuilder/create)
+                               (.setDefaultConnectionConfig
+                                (create-connection-config opts))
+                               (.build))]
+    (-> (HttpAsyncClients/custom)
+        (.setConnectionManager connection-manager)
+        (.setDefaultRequestConfig (create-request-config opts))
+        (.build))))
 
 (defn- to-clojure-future
   "Converts a normal Java future to one similar to the one generated
@@ -188,21 +245,15 @@
 (defrecord Connection []
   AjaxImpl
   (-js-ajax-request
-    [this {:keys [uri method body headers] :as opts} handler]
+    [this opts handler]
     (try
-      (let [request (doto (create-request method)
-                      (.setURI (to-uri uri))
-                      (.setEntity (to-entity body)))
-            request-config (create-request-config opts)
-            builder (doto (HttpAsyncClients/custom)
-                      (.setDefaultRequestConfig request-config))
-            client (doto (.build builder)
-                     (.start))
-            h (create-handler handler)]
-        (doseq [x headers]
-          (let [[h v] x]
-            (.addHeader request h v)))
-        (to-clojure-future (.execute client request h) client))
+      (let [request (create-request opts)
+            ^CloseableHttpAsyncClient client (create-client opts)
+            ^FutureCallback h (create-handler handler)]
+        (.start client)
+        (to-clojure-future
+         (.execute client request (SimpleResponseConsumer/create) h)
+         client))
       (catch Exception ex (fail handler ex)))))
 
 (defn new-api

--- a/test/ajax/test/apache_property.clj
+++ b/test/ajax/test/apache_property.clj
@@ -1,0 +1,285 @@
+(ns ajax.test.apache-property
+  "Property based tests for the Apache HttpClient 5 implementation.
+
+   The pure properties cover the request/response adaptation layer. The
+   round trip properties post to a local server and compare what comes
+   back, so every request body type is encoded, sent, echoed and decoded."
+  (:require [ajax.apache :as apache]
+            [ajax.core :as ajax]
+            [ajax.protocols :as pr]
+            [ajax.ring :as ring]
+            [clojure.string :as string]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [org.httpkit.server :refer [run-server]])
+  (:import [java.io ByteArrayInputStream File InputStream]
+           [java.net SocketTimeoutException URI]
+           [java.util Arrays]
+           [org.apache.hc.client5.http ConnectTimeoutException]
+           [org.apache.hc.client5.http.async.methods SimpleHttpResponse]
+           [org.apache.hc.core5.http ContentType]
+           [org.apache.hc.core5.util Timeout]))
+
+(def ^:dynamic *trials*
+  "Number of test.check trials. The mutation testing harness lowers this,
+   since it runs the whole suite once per mutant."
+  50)
+
+(defn trials [] *trials*)
+
+;;; Test server
+
+(defn- header-echo [headers]
+  (into {} (filter (fn [[k _]] (.startsWith ^String k "x-echo-")) headers)))
+
+(defn- query-param [query-string k]
+  (some (fn [pair]
+          (let [[pk pv] (.split ^String pair "=" 2)]
+            (when (= pk k) pv)))
+        (.split ^String (or query-string "") "&")))
+
+(defn- handler [{:keys [uri body headers query-string request-method]}]
+  (if (not= :post request-method)
+    ;; Every route below is a POST, so this also pins that the request
+    ;; method actually reaches the server.
+    {:status 405 :body "method not allowed"}
+    (case uri
+      "/echo" {:status 200
+               :headers {"Content-Type" "application/octet-stream"}
+               :body (if body (.readAllBytes ^InputStream body) (byte-array 0))}
+      "/headers" {:status 200
+                  :headers (assoc (header-echo headers)
+                                  "Content-Type" "text/plain")
+                  :body ""}
+      "/status" {:status (Integer/parseInt (or (query-param query-string "code") "200"))
+                 :headers {"Content-Type" "text/plain"}
+                 :body "status"}
+      {:status 404 :body "not found"})))
+
+(def ^:private server (atom nil))
+(def ^:private port (atom nil))
+
+(defn- with-server [f]
+  (let [free-port (with-open [s (java.net.ServerSocket. 0)] (.getLocalPort s))]
+    (reset! port free-port)
+    (reset! server (run-server handler {:port free-port :max-body (* 16 1024 1024)}))
+    (try
+      (f)
+      (finally
+        (@server :timeout 100)
+        (reset! server nil)))))
+
+(use-fixtures :once with-server)
+
+(defn- lower-case-keys [headers]
+  (into {} (map (fn [[k v]] [(string/lower-case k) v])) headers))
+
+(defn- endpoint [path]
+  (str "http://localhost:" @port path))
+
+(defn- request!
+  "Runs a cljs-ajax request and returns [ok? response], blocking on the
+   handler rather than on the returned future."
+  [url opts]
+  (let [p (promise)]
+    (ajax/POST url (merge {:handler (fn [r] (deliver p [true r]))
+                           :error-handler (fn [r] (deliver p [false r]))}
+                          opts))
+    (deref p 20000 [::timed-out nil])))
+
+(defn- post-bytes!
+  "POSTs a body of any type ajax.apache supports and returns the echoed bytes."
+  [body]
+  (let [[ok? response] (request! (endpoint "/echo")
+                                 {:body body
+                                  :response-format (ajax/raw-response-format)})]
+    (when-not (true? ok?)
+      (throw (ex-info "Echo request failed" {:response response})))
+    (if response (.readAllBytes ^InputStream response) (byte-array 0))))
+
+;;; Generators
+
+(def gen-bytes
+  (gen/fmap byte-array (gen/vector (gen/choose -128 127) 0 4096)))
+
+(def gen-utf8-string
+  "Strings restricted to non-surrogate code points, so a UTF-8 round trip
+   is lossless rather than the generator emitting unpaired surrogates."
+  (gen/fmap (partial apply str)
+            (gen/vector (gen/fmap char
+                                  (gen/one-of [(gen/choose 32 126)
+                                               (gen/choose 161 591)
+                                               (gen/choose 0x4E00 0x4EFF)]))
+                        0 200)))
+
+(def gen-header-name
+  (gen/fmap #(str "x-echo-" (apply str %))
+            (gen/vector (gen/elements (seq "abcdefghijklmnopqrstuvwxyz0123456789")) 1 12)))
+
+(def gen-header-value
+  ;; Header values are trimmed in transit, so leading and trailing
+  ;; whitespace is not something a client can round trip.
+  (gen/such-that seq
+                 (gen/fmap (comp string/trim (partial apply str))
+                           (gen/vector (gen/elements (seq "abcdefghijklmnopqrstuvwxyz0123456789 .-_")) 1 30))
+                 100))
+
+(def gen-timeout-ms (gen/choose 1 3600000))
+
+(def cookie-policies [:none :default :netscape :standard :standard-strict])
+
+;;; Timeout mapping
+
+(defspec positive-timeouts-survive-the-conversion (trials)
+  (prop/for-all [ms gen-timeout-ms]
+    (= (long ms) (.toMilliseconds ^Timeout (#'apache/to-timeout ms)))))
+
+(defspec absent-or-zero-timeout-means-no-timeout (trials)
+  (prop/for-all [ms (gen/one-of [(gen/return nil)
+                                 (gen/return 0)
+                                 (gen/choose -1000 0)])]
+    (.isDisabled ^Timeout (#'apache/to-timeout ms))))
+
+(defspec timeout-configures-both-connect-and-socket (trials)
+  (prop/for-all [ms gen-timeout-ms]
+    (let [config (#'apache/create-connection-config {:timeout ms})]
+      (and (= (long ms) (.toMilliseconds (.getConnectTimeout config)))
+           (= (long ms) (.toMilliseconds (.getSocketTimeout config)))))))
+
+(defspec socket-timeout-overrides-timeout (trials)
+  (prop/for-all [ms gen-timeout-ms
+                 socket-ms gen-timeout-ms]
+    (let [config (#'apache/create-connection-config {:timeout ms
+                                                     :socket-timeout socket-ms})]
+      (and (= (long ms) (.toMilliseconds (.getConnectTimeout config)))
+           (= (long socket-ms) (.toMilliseconds (.getSocketTimeout config)))))))
+
+;;; Cookie policies
+
+(defspec cookie-policy-is-set-exactly-when-requested (trials)
+  (prop/for-all [policy (gen/elements (cons nil cookie-policies))]
+    (let [spec (.getCookieSpec (#'apache/create-request-config
+                                {:cookie-policy policy}))]
+      (if policy
+        (string? spec)
+        (nil? spec)))))
+
+(deftest cookie-policies-map-to-httpclient-5-specs
+  (is (= "ignore" (apache/get-cookie-policy {:cookie-policy :none})))
+  (is (= "strict" (apache/get-cookie-policy {:cookie-policy :standard-strict})))
+  (doseq [policy [:default :netscape :standard]]
+    (testing (str policy " maps to the RFC 6265 relaxed spec")
+      (is (= "relaxed" (apache/get-cookie-policy {:cookie-policy policy}))))))
+
+;;; Response adaptation
+
+(defn- simple-response [code headers body]
+  (let [response (SimpleHttpResponse/create (int code))]
+    (doseq [[k v] headers]
+      (.addHeader response ^String k ^String v))
+    (when body
+      (.setBody response ^bytes body ContentType/APPLICATION_OCTET_STREAM))
+    response))
+
+(defspec wrapper-mirrors-the-underlying-response (trials)
+  (prop/for-all [code (gen/choose 100 599)
+                 headers (gen/map gen-header-name gen-header-value)
+                 body (gen/one-of [(gen/return nil) gen-bytes])]
+    (let [wrapper (apache/->HttpResponseWrapper (simple-response code headers body))]
+      (and (= code (pr/-status wrapper))
+           (= headers (select-keys (pr/-get-all-headers wrapper) (keys headers)))
+           (every? #(= (get headers %) (pr/-get-response-header wrapper %))
+                   (keys headers))
+           (false? (pr/-was-aborted wrapper))
+           (if body
+             (Arrays/equals ^bytes body
+                            (.readAllBytes ^InputStream (pr/-body wrapper)))
+             (nil? (pr/-body wrapper)))))))
+
+;;; Failure adaptation
+
+(defn- captured-response [f]
+  (let [captured (atom nil)]
+    (f (fn [response] (reset! captured response)))
+    @captured))
+
+(defspec timeouts-report-a-status-of-minus-one (trials)
+  (prop/for-all [message (gen/such-that seq gen-header-value)
+                 timeout-class (gen/elements [:socket :connect])]
+    (let [ex (case timeout-class
+               :socket (SocketTimeoutException. message)
+               :connect (ConnectTimeoutException. message))
+          response (captured-response #(#'apache/fail % ex))]
+      (and (= -1 (:status response))
+           (= message (:status-text response))
+           (false? (:was-aborted response))
+           (identical? ex (:exception response))))))
+
+(defspec other-failures-report-a-status-of-zero (trials)
+  (prop/for-all [message (gen/such-that seq gen-header-value)]
+    (let [response (captured-response
+                    #(#'apache/fail % (java.io.IOException. ^String message)))]
+      (and (= 0 (:status response))
+           (false? (:was-aborted response))))))
+
+(deftest cancellation-looks-like-an-aborted-xhr
+  (let [response (captured-response #(#'apache/cancel %))]
+    (is (= -1 (:status response)))
+    (is (= "Cancelled" (:status-text response)))
+    (is (true? (:was-aborted response)))))
+
+;;; URI handling
+
+(defspec spaces-in-uris-are-escaped (trials)
+  (prop/for-all [path (gen/vector (gen/elements ["a" "b" " " "c"]) 1 10)]
+    (let [uri (str "http://example.com/" (apply str path))]
+      (= (URI. (string/replace uri " " "%20"))
+         (#'apache/to-uri uri)))))
+
+;;; Round trips against a real server
+
+(defspec byte-array-bodies-round-trip (trials)
+  (prop/for-all [body gen-bytes]
+    (Arrays/equals ^bytes body ^bytes (post-bytes! body))))
+
+(defspec string-bodies-round-trip-as-utf-8 (trials)
+  (prop/for-all [body gen-utf8-string]
+    (Arrays/equals ^bytes (.getBytes body "UTF-8") ^bytes (post-bytes! body))))
+
+(defspec input-stream-bodies-round-trip (trials)
+  (prop/for-all [body gen-bytes]
+    (Arrays/equals ^bytes body ^bytes (post-bytes! (ByteArrayInputStream. body)))))
+
+(defspec file-bodies-round-trip (trials)
+  (prop/for-all [body gen-bytes]
+    (let [file (doto (File/createTempFile "cljs-ajax-property" ".bin")
+                 (.deleteOnExit))]
+      (try
+        (with-open [out (java.io.FileOutputStream. file)]
+          (.write out ^bytes body))
+        (Arrays/equals ^bytes body ^bytes (post-bytes! file))
+        (finally (.delete file))))))
+
+(defspec request-headers-reach-the-server-and-come-back (trials)
+  (prop/for-all [headers (gen/map gen-header-name gen-header-value {:min-elements 1})]
+    (let [[ok? response] (request! (endpoint "/headers")
+                                   {:headers headers
+                                    :body ""
+                                    :response-format (ring/ring-response-format)})]
+      (and (true? ok?)
+           (= 200 (:status response))
+           ;; HTTP header names are case insensitive and servers are free
+           ;; to send back whatever casing they like.
+           (= headers (select-keys (lower-case-keys (:headers response))
+                                   (keys headers)))))))
+
+(defspec status-codes-are-reported-verbatim (trials)
+  (prop/for-all [code (gen/elements [200 201 204 400 404 418 500 503])]
+    (let [[ok? response] (request! (str (endpoint "/status") "?code=" code)
+                                   {:body ""
+                                    :response-format (ajax/raw-response-format)})]
+      (if (< code 400)
+        (true? ok?)
+        (and (false? ok?) (= code (:status response)))))))

--- a/test/ajax/test/jvm_runner.clj
+++ b/test/ajax/test/jvm_runner.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :as t]))
 
 (def test-namespaces
-  ['ajax.test.core
+  ['ajax.test.apache-property
+   'ajax.test.core
    'ajax.test.server-interaction
    'ajax.test.url])
 

--- a/test/ajax/test/mutation.clj
+++ b/test/ajax/test/mutation.clj
@@ -1,0 +1,205 @@
+(ns ajax.test.mutation
+  "Mutation testing for the Apache HttpClient 5 implementation.
+
+   Each operator applies one defect to `src/ajax/apache.clj`, the namespace
+   is reloaded from the mutated source, and the property suite is run
+   against it. A mutant the suite fails to notice is a survivor: it marks
+   behaviour no test asserts.
+
+   Run with `clojure -X:mutation`."
+  (:require [ajax.test.apache-property :as property]
+            [clojure.java.io :as io]
+            [clojure.string :as string]
+            [clojure.test :as t])
+  (:import [java.io PushbackReader StringWriter]))
+
+(def ^:private source-path "src/ajax/apache.clj")
+
+(def ^:private suite ['ajax.test.apache-property])
+
+(def ^:private mutation-trials
+  "Trials per property while mutation testing. The whole suite runs once
+   per mutant, so this trades breadth of sampling for the number of
+   defects we can try."
+  10)
+
+;;; Metadata preserving walk. `clojure.walk` drops metadata on
+;;; collections, which would strip the type hints on argument vectors.
+
+(defn- walk-form [f form]
+  (f (cond
+       (list? form) (with-meta (apply list (map (partial walk-form f) form))
+                      (meta form))
+       (instance? clojure.lang.IMapEntry form)
+       (clojure.lang.MapEntry/create (walk-form f (key form))
+                                     (walk-form f (val form)))
+
+       (seq? form) (with-meta (doall (map (partial walk-form f) form))
+                     (meta form))
+       (record? form) form
+       (coll? form) (with-meta (into (empty form) (map (partial walk-form f) form))
+                      (meta form))
+       :else form)))
+
+(defn- occurrences [forms match?]
+  (let [found (atom 0)]
+    (walk-form (fn [form] (when (match? form) (swap! found inc)) form) forms)
+    @found))
+
+(defn- mutate [forms match? replace-fn n]
+  (let [seen (atom -1)]
+    (walk-form (fn [form]
+                 (if (and (match? form) (= n (swap! seen inc)))
+                   (replace-fn form)
+                   form))
+               forms)))
+
+;;; Operators
+
+(defn- literal [x] (fn [form] (= form x)))
+
+(defn- call-to [sym]
+  (fn [form] (and (seq? form) (= sym (first form)))))
+
+(defn- always [x] (fn [_] x))
+
+(def operators
+  [{:id :positive-timeout-check
+    :doc "pos? -> neg?: treats every positive timeout as no timeout"
+    :match (literal 'pos?) :replace (always 'neg?)}
+   {:id :timeout-fallback
+    :doc "or -> and: drops the socket-timeout/timeout fallback and the
+          timeout exception union"
+    :match (literal 'or) :replace (always 'and)}
+   {:id :no-timeout-constant
+    :doc "Timeout/DISABLED -> 1ms: turns 'no timeout' into an instant one"
+    :match (literal 'Timeout/DISABLED)
+    :replace (always '(Timeout/ofMilliseconds 1))}
+   {:id :connect-timeout-setter
+    :doc ".setConnectTimeout -> .setSocketTimeout: leaves the connect
+          timeout at the HttpClient default"
+    :match (literal '.setConnectTimeout) :replace (always '.setSocketTimeout)}
+   {:id :nil-safe-body
+    :doc "some-> -> ->: stops guarding against an absent response body"
+    :match (literal 'some->) :replace (always '->)}
+   {:id :error-status
+    :doc "-1 -> 1: loses the negative status that marks timeouts and aborts"
+    :match (literal -1) :replace (always 1)}
+   {:id :aborted-flag
+    :doc "flips :was-aborted on the synthesised responses"
+    :match #(and (map? %) (contains? % :was-aborted))
+    :replace #(update % :was-aborted not)}
+   {:id :strict-cookie-spec
+    :doc "STRICT -> RELAXED: silently downgrades :standard-strict"
+    :match (literal 'StandardCookieSpec/STRICT)
+    :replace (always 'StandardCookieSpec/RELAXED)}
+   {:id :ignore-cookie-spec
+    :doc "IGNORE -> RELAXED: silently enables cookies for :none"
+    :match (literal 'StandardCookieSpec/IGNORE)
+    :replace (always 'StandardCookieSpec/RELAXED)}
+   {:id :body-charset
+    :doc "UTF-8 -> US-ASCII: mangles non-ascii string bodies"
+    :match (literal "UTF-8") :replace (always "US-ASCII")}
+   {:id :status-accessor
+    :doc ".getCode -> .getVersion: reports something other than the status"
+    :match (literal '.getCode) :replace (always '.getVersion)}
+   {:id :header-name-accessor
+    :doc ".getName -> .getValue: keys the header map by value"
+    :match (literal '.getName) :replace (always '.getValue)}
+   {:id :request-method
+    :doc "sends every request as a GET"
+    :match (call-to 'AsyncRequestBuilder/create)
+    :replace (always '(AsyncRequestBuilder/create "GET"))}
+   {:id :request-uri
+    :doc "never sets the request URI"
+    :match (call-to '.setUri) :replace (always nil)}
+   {:id :request-body
+    :doc "never attaches the request entity"
+    :match (call-to '.setEntity) :replace (always nil)}
+   {:id :request-headers
+    :doc "never adds the request headers"
+    :match (call-to '.addHeader) :replace (always nil)}])
+
+;;; Running
+
+(defn- read-forms [path]
+  (with-open [reader (PushbackReader. (io/reader path))]
+    (doall (take-while #(not= ::eof %)
+                       (repeatedly #(read {:eof ::eof} reader))))))
+
+(defn- load-forms! [forms]
+  (binding [*ns* *ns*]
+    (doseq [form forms]
+      (eval form))))
+
+(defn- restore! []
+  (require 'ajax.apache :reload))
+
+(defn- suite-passes?
+  "Runs the property suite quietly. Any failure, error or thrown
+   exception counts as the mutant being killed."
+  []
+  (let [out (StringWriter.)]
+    (try
+      (binding [t/*test-out* out
+                *out* out
+                *err* out
+                property/*trials* mutation-trials]
+        (let [{:keys [fail error]} (apply t/run-tests suite)]
+          (zero? (+ fail error))))
+      (catch Throwable _ false))))
+
+(defn- mutants [forms]
+  (for [{:keys [id doc match replace]} operators
+        n (range (occurrences forms match))]
+    {:operator id
+     :doc doc
+     :occurrence n
+     :forms (mutate forms match replace n)}))
+
+(defn- kills? [{:keys [forms]}]
+  (try
+    (load-forms! forms)
+    (not (suite-passes?))
+    (catch Throwable _
+      ;; A mutant that will not compile is not a useful signal, but it is
+      ;; not a survivor either.
+      true)
+    (finally (restore!))))
+
+(defn- report [{:keys [total killed survivors]}]
+  (println)
+  (println (format "Mutation score: %d/%d killed (%.0f%%)"
+                   killed total (* 100.0 (/ (double killed) (max total 1)))))
+  (when (seq survivors)
+    (println)
+    (println "Survivors, behaviour no test asserts:")
+    (doseq [{:keys [operator occurrence doc]} survivors]
+      (println (format "  %s #%d  %s"
+                       (name operator) occurrence
+                       (string/replace (str doc) #"\s+" " "))))))
+
+(defn run-mutation-tests
+  "Entry point for `clojure -X:mutation`. Throws if any mutant survives."
+  [_]
+  (require 'ajax.apache)
+  (let [forms (read-forms source-path)
+        candidates (mutants forms)]
+    (println (format "Running %d mutants of %s against %s"
+                     (count candidates) source-path (string/join ", " suite)))
+    (when-not (suite-passes?)
+      (throw (ex-info "The property suite fails before any mutation" {})))
+    (let [results (doall (map (fn [mutant]
+                                (print ".") (flush)
+                                (assoc mutant :killed (kills? mutant)))
+                              candidates))
+          survivors (remove :killed results)
+          summary {:total (count results)
+                   :killed (count (filter :killed results))
+                   :survivors (map #(select-keys % [:operator :occurrence :doc])
+                                   survivors)}]
+      (report summary)
+      (when (seq survivors)
+        (throw (ex-info "Mutants survived the test suite"
+                        (select-keys summary [:total :killed :survivors]))))
+      summary)))


### PR DESCRIPTION
Builds on #288. The first two commits are that PR's; the last two are the
content here, and they are independent of each other.

## Property based tests

`ajax.test.apache-property`, part of `clojure -X:test`. Adds
`org.clojure/test.check` to the `:test` alias.

Pure properties cover timeout mapping, cookie specs, the response wrapper over
a synthesised `SimpleHttpResponse`, and the statuses reported for timeouts,
other failures and cancellation.

Round trip properties post to a local server and compare what comes back. A
byte array, a string, a file and an input stream take four different paths
through the entity producers; the existing suites exercise one. The test server
rejects anything that is not a POST, so the request method is asserted too.

## Mutation testing harness

`clojure -X:mutation`, via a new alias. Nothing else depends on it and it is
not part of `clojure -X:test`.

It applies one defect at a time to `apache.clj`, reloads the namespace from the
mutated source, and runs the property suite. A mutant the suite still passes is
reported as a survivor and the run exits non-zero. 19 mutants, all killed.

The first run found one survivor: mutating every request to GET changed
nothing, because the test server dispatched on path alone. Nothing asserted the
HTTP method reached the wire, and coverage reported that path covered.

Operators match on a predicate over the form rather than on a token, to avoid
equivalent mutants. Flipping the interrupt flag passed to `Future.cancel` is
unobservable; flipping `:was-aborted` is not.

A mutation harness is unusual in a library repo. It is the last commit, so it
can be dropped without touching the property tests.

## Verification

```
clojure -X:test        53 tests, 138 assertions, 0 failures
clojure -X:mutation    19/19 mutants killed
```

Rest of `DEVELOPMENT.md` unchanged from PR 1.
