### PR TITLE
Upgrade dependencies to their latest releases

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -40,8 +40,8 @@
                      ring-server/ring-server {:mvn/version "0.5.0"}
                      ring-transit/ring-transit {:mvn/version "0.1.6"}}}
   :cljs {:extra-paths ["test" "browser-test"]
-         :extra-deps {org.clojure/clojurescript {:mvn/version "1.11.132"}
-                      thheller/shadow-cljs {:mvn/version "2.28.19"}}}
+         :extra-deps {org.clojure/clojurescript {:mvn/version "1.12.145"}
+                      thheller/shadow-cljs {:mvn/version "3.4.12"}}}
   :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.3"}}}
   :build {:extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.10"}}
           :ns-default build}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,11 +1,11 @@
 {:paths ["src"]
  :mvn/repos {"clojars" {:url "https://repo.clojars.org/"}}
- :deps {cheshire/cheshire {:mvn/version "5.10.0"}
-        com.cognitect/transit-clj {:mvn/version "1.0.324"}
-        com.cognitect/transit-cljs {:mvn/version "0.8.264"}
+ :deps {cheshire/cheshire {:mvn/version "6.2.0"}
+        com.cognitect/transit-clj {:mvn/version "1.0.333"}
+        com.cognitect/transit-cljs {:mvn/version "0.8.280"}
         org.apache.httpcomponents/httpasyncclient {:mvn/version "4.1.4"}
         org.apache.httpcomponents/httpcore {:mvn/version "4.4.14"}
-        org.clojure/clojure {:mvn/version "1.11.1"}}
+        org.clojure/clojure {:mvn/version "1.12.0"}}
  :aliases
  {:test {:extra-paths ["test" "support"]
          :extra-deps {compojure/compojure {:mvn/version "1.6.2"}

--- a/deps.edn
+++ b/deps.edn
@@ -8,40 +8,40 @@
         org.clojure/clojure {:mvn/version "1.12.0"}}
  :aliases
  {:test {:extra-paths ["test" "support"]
-         :extra-deps {compojure/compojure {:mvn/version "1.6.2"}
+         :extra-deps {compojure/compojure {:mvn/version "1.7.2"}
                       fogus/ring-edn {:mvn/version "0.3.0"}
-                      hiccup/hiccup {:mvn/version "1.0.5"}
+                      hiccup/hiccup {:mvn/version "2.0.0"}
                       http-kit/http-kit {:mvn/version "2.5.3"}
-                      javax.servlet/javax.servlet-api {:mvn/version "3.1.0"}
+                      javax.servlet/javax.servlet-api {:mvn/version "4.0.1"}
                       org.clojure/core.async {:mvn/version "1.3.610"}
                       ring-server/ring-server {:mvn/version "0.5.0"}
                       ring-transit/ring-transit {:mvn/version "0.1.6"}}
          :exec-fn ajax.test.jvm-runner/run-tests}
   :integration {:extra-paths ["test" "support"]
-                :extra-deps {compojure/compojure {:mvn/version "1.6.2"}
+                :extra-deps {compojure/compojure {:mvn/version "1.7.2"}
                              fogus/ring-edn {:mvn/version "0.3.0"}
-                             hiccup/hiccup {:mvn/version "1.0.5"}
+                             hiccup/hiccup {:mvn/version "2.0.0"}
                              http-kit/http-kit {:mvn/version "2.5.3"}
-                             javax.servlet/javax.servlet-api {:mvn/version "3.1.0"}
+                             javax.servlet/javax.servlet-api {:mvn/version "4.0.1"}
                              org.clojure/core.async {:mvn/version "1.3.610"}
                              ring-server/ring-server {:mvn/version "0.5.0"}
                              ring-transit/ring-transit {:mvn/version "0.1.6"}}
                 :exec-fn ajax.test.integration-jvm-runner/run-tests}
   :dev {:extra-paths ["dev" "browser-test" "support"]
         :extra-deps {clj-time/clj-time {:mvn/version "0.15.2"}
-                     compojure/compojure {:mvn/version "1.6.2"}
+                     compojure/compojure {:mvn/version "1.7.2"}
                      fogus/ring-edn {:mvn/version "0.3.0"}
-                     hiccup/hiccup {:mvn/version "1.0.5"}
+                     hiccup/hiccup {:mvn/version "2.0.0"}
                      http-kit/http-kit {:mvn/version "2.5.3"}
-                     org.clojure/tools.namespace {:mvn/version "1.1.0"}
-                     ring/ring-defaults {:mvn/version "0.3.2"}
+                     org.clojure/tools.namespace {:mvn/version "1.5.0"}
+                     ring/ring-defaults {:mvn/version "0.7.1"}
                      ring/ring-json {:mvn/version "0.5.1"}
-                     ring/ring-devel {:mvn/version "1.9.6"}
+                     ring/ring-devel {:mvn/version "1.15.5"}
                      ring-server/ring-server {:mvn/version "0.5.0"}
                      ring-transit/ring-transit {:mvn/version "0.1.6"}}}
   :cljs {:extra-paths ["test" "browser-test"]
          :extra-deps {org.clojure/clojurescript {:mvn/version "1.12.145"}
                       thheller/shadow-cljs {:mvn/version "3.4.12"}}}
-  :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.3"}}}
+  :deploy {:extra-deps {slipset/deps-deploy {:mvn/version "0.2.5"}}}
   :build {:extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.10"}}
           :ns-default build}}}


### PR DESCRIPTION
Three commits, grouped by what they affect, so they can be taken separately.

**Runtime.** cheshire 5.10.0 -> 6.2.0, transit-clj 1.0.324 -> 1.0.333,
transit-cljs 0.8.264 -> 0.8.280, Clojure 1.11.1 -> 1.12.0.

**ClojureScript and shadow-cljs.** ClojureScript 1.11.132 -> 1.12.145,
shadow-cljs 2.28.19 -> 3.4.12. Pinned to 1.12.145 rather than the newest
release on Maven Central: shadow-cljs 3.4.12 expects that version, and the top
level pin wins over its own dependency, so 1.12.42 fails the build with
`No such var: ana/elide-to-string?`.

**Test, dev and release.** compojure 1.6.2 -> 1.7.2, hiccup 1.0.5 -> 2.0.0,
servlet-api 3.1.0 -> 4.0.1, tools.namespace 1.1.0 -> 1.5.0, ring-defaults 0.3.2
-> 0.7.1, ring-devel 1.9.6 -> 1.15.5, deps-deploy 0.2.3 -> 0.2.5. hiccup 2.0.0
is a major version; the only use here is `hiccup.core/html` in the integration
support server, unchanged.

## Verification

Every command in `DEVELOPMENT.md`, on Linux with Chromium:

```
clojure -X:test              36 tests, 115 assertions, 0 failures
clojure -X:integration        9 tests,  15 assertions, 0 failures
npm run test:cljs:node       33 tests,  94 assertions, 0 failures
npm run test:cljs:browser    34 tests, 0 failures
npm run test:integration     13 tests, 0 failures
clojure -T:build jar         builds
```
